### PR TITLE
[cdc_fuse_fs] Fix various issues

### DIFF
--- a/cdc_fuse_fs/main.cc
+++ b/cdc_fuse_fs/main.cc
@@ -72,6 +72,31 @@ bool IsUpToDate(const std::string& components_arg) {
   return true;
 }
 
+absl::Status CreateMountDir(const std::vector<char*>& args) {
+  // Assume the mount dir is the last argument.
+  size_t argc = args.size();
+  if (argc < 2 || !args[argc - 1]) {
+    return absl::InvalidArgumentError(
+        "The last argument must be the mount directory");
+  }
+  std::string mount_dir = args[argc - 1];
+  if (mount_dir[0] == '-') {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "The last argument must be the mount directory, but is '%s'",
+        mount_dir));
+  }
+
+  // Expand ~ etc.
+  RETURN_IF_ERROR(cdc_ft::path::ExpandPathVariables(&mount_dir),
+                  "Failed to expand mount directory '%s'", mount_dir);
+
+  // Create expanded directory.
+  RETURN_IF_ERROR(cdc_ft::path::CreateDirRec(mount_dir),
+                  "Failed to create directory '%s'", mount_dir);
+
+  return absl::OkStatus();
+}
+
 }  // namespace
 }  // namespace cdc_ft
 
@@ -104,7 +129,7 @@ ABSL_FLAG(uint32_t, access_idle_timeout, cdc_ft::DataProvider::kAccessIdleSec,
 
 static_assert(static_cast<int>(absl::StatusCode::kOk) == 0, "kOk != 0");
 
-// Usage: cdc_fuse_fs <ABSL_FLAGs> -- mount_dir [-d|-s|..]
+// Usage: cdc_fuse_fs <ABSL_FLAGs> -- [-d|-s|.. mount_dir]
 // Any args after --  are FUSE args, search third_party/fuse for FUSE_OPT_KEY or
 // FUSE_LIB_OPT (there doesn't seem to be a place where they're all described).
 int main(int argc, char* argv[]) {
@@ -136,9 +161,16 @@ int main(int argc, char* argv[]) {
   printf("%s\n", cdc_ft::kFuseUpToDate);
   fflush(stdout);
 
+  // Create mount dir if it doesn't exist yet.
+  absl::Status status = cdc_ft::CreateMountDir(mount_args);
+  if (!status.ok()) {
+    LOG_ERROR("Failed to create mount directory: %s", status.ToString());
+    return 1;
+  }
+
   // Create fs. The rest of the flags are mount flags, so pass them along.
-  absl::Status status = cdc_ft::cdc_fuse_fs::Initialize(
-      static_cast<int>(mount_args.size()), mount_args.data());
+  status = cdc_ft::cdc_fuse_fs::Initialize(static_cast<int>(mount_args.size()),
+                                           mount_args.data());
   if (!status.ok()) {
     LOG_ERROR("Failed to initialize file system: %s", status.ToString());
     return static_cast<int>(status.code());

--- a/cdc_fuse_fs/main.cc
+++ b/cdc_fuse_fs/main.cc
@@ -43,12 +43,25 @@ absl::StatusOr<bool> IsUpToDate(const std::string& components_arg) {
 
   std::vector<GameletComponent> components =
       GameletComponent::FromCommandLineArgs(components_arg);
+  if (components.size() == 0) {
+    LOG_DEBUG("Invalid components arg '%s'", components_arg);
+    return false;
+  }
+
   std::vector<GameletComponent> our_components;
   absl::Status status =
       GameletComponent::Get({path::Join(component_dir, kFuseFilename),
                              path::Join(component_dir, kLibFuseFilename)},
                             &our_components);
-  if (!status.ok() || components != our_components) {
+  if (!status.ok()) {
+    LOG_DEBUG("Failed to get component data: %s", status.ToString())
+    return false;
+  }
+
+  if (components != our_components) {
+    LOG_DEBUG("Component mismatch, args don't match ours '%s' != '%s'",
+              GameletComponent::ToCommandLineArgs(components),
+              GameletComponent::ToCommandLineArgs(our_components));
     return false;
   }
 

--- a/cdc_indexer/indexer.cc
+++ b/cdc_indexer/indexer.cc
@@ -334,8 +334,7 @@ void Indexer::Worker::Run() {
 absl::Status Indexer::Worker::IndexFile(const std::string& filepath) {
   std::FILE* fin = std::fopen(filepath.c_str(), "rb");
   if (!fin) {
-    return ErrnoToCanonicalStatus(
-        errno, absl::StrFormat("failed to open file '%s'", filepath));
+    return ErrnoToCanonicalStatus(errno, "failed to open file '%s'", filepath);
   }
   path::FileCloser closer(fin);
   std::fseek(fin, 0, SEEK_SET);
@@ -349,8 +348,8 @@ absl::Status Indexer::Worker::IndexFile(const std::string& filepath) {
     size_t cnt = std::fread(buf.data(), sizeof(uint8_t), buf.size(), fin);
     err = std::ferror(fin);
     if (err) {
-      return ErrnoToCanonicalStatus(
-          err, absl::StrFormat("failed to read from file '%s'", filepath));
+      return ErrnoToCanonicalStatus(err, "failed to read from file '%s'",
+                                    filepath);
     }
     if (cnt) {
       chunker.Process(buf.data(), cnt);

--- a/cdc_indexer/main.cc
+++ b/cdc_indexer/main.cc
@@ -273,8 +273,8 @@ absl::Status WriteResultsFile(const std::string& filepath,
   bool exists = path::FileExists(filepath);
   std::FILE* fout = std::fopen(filepath.c_str(), "a");
   if (!fout) {
-    return ErrnoToCanonicalStatus(
-        errno, absl::StrFormat("Couldn't write to file '%s'", filepath));
+    return ErrnoToCanonicalStatus(errno, "Couldn't write to file '%s'",
+                                  filepath);
   }
 
   path::FileCloser closer(fout);

--- a/common/BUILD
+++ b/common/BUILD
@@ -35,16 +35,18 @@ cc_library(
             # Additional warnings from @com_github_dirent
             "/wd4505",  # unreferenced function with internal linkage has been removed
         ],
-        "//conditions:default": ["/wd4505"],
+        "//conditions:default": [],
     }),
     deps = [
         ":path",
         ":platform",
-        "@com_github_dirent//:dirent",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
-    ],
+    ] + select({
+        "//tools:windows": ["@com_github_dirent//:dirent"],
+        "//conditions:default": [],
+    }),
 )
 
 cc_test(

--- a/common/BUILD
+++ b/common/BUILD
@@ -66,6 +66,7 @@ cc_library(
     deps = [
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
     ],
 )
 

--- a/common/dir_iter.cc
+++ b/common/dir_iter.cc
@@ -221,8 +221,8 @@ bool DirectoryIterator::Open(const std::string& path,
     impl_->PushDir(dir, path::BaseName(path));
     return true;
   }
-  impl_->SetStatus(ErrnoToCanonicalStatus(
-      errno, absl::StrFormat("Failed to open directory '%s'", path)));
+  impl_->SetStatus(
+      ErrnoToCanonicalStatus(errno, "Failed to open directory '%s'", path));
   return false;
 }
 
@@ -259,7 +259,7 @@ bool DirectoryIterator::NextEntry(DirectoryEntry* entry) {
           // Ignore access errors and proceed.
         } else {
           impl_->SetStatus(ErrnoToCanonicalStatus(
-              errno, absl::StrFormat("Failed to open directory '%s'", subdir)));
+              errno, "Failed to open directory '%s'", subdir));
           return false;
         }
       }
@@ -278,8 +278,7 @@ bool DirectoryIterator::NextEntry(DirectoryEntry* entry) {
 
   if (errno) {
     impl_->SetStatus(ErrnoToCanonicalStatus(
-        errno, absl::StrFormat("Failed to iterate over directory '%s'",
-                               impl_->DirsPath())));
+        errno, "Failed to iterate over directory '%s'", impl_->DirsPath()));
   }
   return false;
 }

--- a/common/errno_mapping.cc
+++ b/common/errno_mapping.cc
@@ -166,4 +166,12 @@ absl::Status ErrnoToCanonicalStatus(int error_number,
                       absl::StrCat(message, ": ", strerror(error_number)));
 }
 
+absl::Status ErrorCodeToCanonicalStatus(const std::error_code& code,
+                                        absl::string_view message) {
+  absl::StatusCode absl_code = code.category() == std::system_category()
+                                   ? ErrnoToCanonicalCode(code.value())
+                                   : absl::StatusCode::kUnknown;
+  return absl::Status(absl_code, absl::StrCat(message, ": ", code.message()));
+}
+
 }  // namespace cdc_ft

--- a/common/errno_mapping.cc
+++ b/common/errno_mapping.cc
@@ -16,8 +16,6 @@
 
 #include <errno.h>
 
-#include <string>
-
 namespace cdc_ft {
 
 absl::StatusCode ErrnoToCanonicalCode(int error_number) {
@@ -158,20 +156,6 @@ absl::StatusCode ErrnoToCanonicalCode(int error_number) {
     default:
       return absl::StatusCode::kUnknown;
   }
-}
-
-absl::Status ErrnoToCanonicalStatus(int error_number,
-                                    absl::string_view message) {
-  return absl::Status(ErrnoToCanonicalCode(error_number),
-                      absl::StrCat(message, ": ", strerror(error_number)));
-}
-
-absl::Status ErrorCodeToCanonicalStatus(const std::error_code& code,
-                                        absl::string_view message) {
-  absl::StatusCode absl_code = code.category() == std::system_category()
-                                   ? ErrnoToCanonicalCode(code.value())
-                                   : absl::StatusCode::kUnknown;
-  return absl::Status(absl_code, absl::StrCat(message, ": ", code.message()));
 }
 
 }  // namespace cdc_ft

--- a/common/errno_mapping.h
+++ b/common/errno_mapping.h
@@ -29,6 +29,10 @@ absl::StatusCode ErrnoToCanonicalCode(int error_number);
 absl::Status ErrnoToCanonicalStatus(int error_number,
                                     absl::string_view message);
 
+// Creates a status by converting the std |code to an absl code.
+absl::Status ErrorCodeToCanonicalStatus(const std::error_code& code,
+                                        absl::string_view message);
+
 }  // namespace cdc_ft
 
 #endif  // COMMON_ERRNO_MAPPING_H_

--- a/common/errno_mapping.h
+++ b/common/errno_mapping.h
@@ -17,8 +17,10 @@
 #ifndef COMMON_ERRNO_MAPPING_H_
 #define COMMON_ERRNO_MAPPING_H_
 
+#include <string>
+
 #include "absl/status/status.h"
-#include "absl/strings/string_view.h"
+#include "absl/strings/str_format.h"
 
 namespace cdc_ft {
 
@@ -26,12 +28,27 @@ namespace cdc_ft {
 absl::StatusCode ErrnoToCanonicalCode(int error_number);
 
 // Creates a status by converting the errno |error_number| to an absl code.
+template <typename... Args>
 absl::Status ErrnoToCanonicalStatus(int error_number,
-                                    absl::string_view message);
+                                    const absl::FormatSpec<Args...>& format,
+                                    Args... args) {
+  if (error_number == 0) return absl::OkStatus();
+  std::string msg = absl::StrFormat(format, args...);
+  return absl::Status(ErrnoToCanonicalCode(error_number),
+                      absl::StrCat(msg, ": ", strerror(error_number)));
+}
 
-// Creates a status by converting the std |code to an absl code.
+template <typename... Args>
 absl::Status ErrorCodeToCanonicalStatus(const std::error_code& code,
-                                        absl::string_view message);
+                                        const absl::FormatSpec<Args...>& format,
+                                        Args... args) {
+  if (!code) return absl::OkStatus();
+  std::string msg = absl::StrFormat(format, args...);
+  absl::StatusCode absl_code = code.category() == std::system_category()
+                                   ? ErrnoToCanonicalCode(code.value())
+                                   : absl::StatusCode::kUnknown;
+  return absl::Status(absl_code, absl::StrCat(msg, ": ", code.message()));
+}
 
 }  // namespace cdc_ft
 

--- a/common/path.cc
+++ b/common/path.cc
@@ -37,6 +37,7 @@
 #include <stdlib.h>  // putenv
 #include <unistd.h>  // readlink
 #include <utime.h>   // struct utimbuf
+#include <wordexp.h>
 #define __stat64 stat64
 #define _chmod chmod
 #endif
@@ -198,8 +199,8 @@ absl::Status GetKnownFolderPath(FolderId folder_id, std::string* path) {
 }
 #endif
 
+absl::Status ExpandPathVariables(std::string* path) {
 #if PLATFORM_WINDOWS
-absl::Status ExpandEnvironmentPathVariables(std::string* path) {
   std::wstring wchar_path = Util::Utf8ToWideStr(*path);
 
   DWORD size = ::ExpandEnvironmentStrings(wchar_path.c_str(), nullptr, 0);
@@ -217,8 +218,18 @@ absl::Status ExpandEnvironmentPathVariables(std::string* path) {
   wchar_expanded.pop_back();
   *path = Util::WideToUtf8Str(wchar_expanded);
   return absl::OkStatus();
-}
+#else
+  wordexp_t res;
+  wordexp(path->c_str(), &res, 0);
+  if (res.we_wordc > 1) {
+    return absl::InvalidArgumentError(
+        "Path expands to multiple results (did you use * etc. ?");
+  }
+  *path = res.we_wordv[0];
+  wordfree(&res);
+  return absl::OkStatus();
 #endif
+}
 
 absl::Status GetEnv(const std::string& name, std::string* value) {
   value->clear();

--- a/common/path.cc
+++ b/common/path.cc
@@ -974,9 +974,8 @@ absl::Status CreateSymlink(const std::string& target,
                                               error_code);
   }
   if (error_code) {
-    assert(error_code.category() == std::system_category());
-    return ErrnoToCanonicalStatus(
-        error_code.value(),
+    return ErrorCodeToCanonicalStatus(
+        error_code,
         absl::StrFormat("Failed to create symlink '%s' with target '%s'",
                         link_path, target));
   }
@@ -989,9 +988,8 @@ absl::StatusOr<std::string> GetSymlinkTarget(const std::string& link_path) {
   std::filesystem::path symlink_target =
       std::filesystem::read_symlink(link_path_u8, error_code);
   if (error_code) {
-    return ErrnoToCanonicalStatus(
-        error_code.value(),
-        absl::StrFormat("Failed to read symlink '%s'", link_path));
+    return ErrorCodeToCanonicalStatus(
+        error_code, absl::StrFormat("Failed to read symlink '%s'", link_path));
   }
   return symlink_target.u8string();
 }
@@ -1015,10 +1013,8 @@ absl::Status CreateDir(const std::string& path) {
   std::error_code error_code;
   std::filesystem::create_directory(std::filesystem::u8path(path), error_code);
   if (error_code) {
-    assert(error_code.category() == std::system_category());
-    return ErrnoToCanonicalStatus(
-        error_code.value(),
-        absl::StrFormat("Failed to create directory '%s'", path));
+    return ErrorCodeToCanonicalStatus(
+        error_code, absl::StrFormat("Failed to create directory '%s'", path));
   }
   return absl::OkStatus();
 }
@@ -1028,10 +1024,8 @@ absl::Status CreateDirRec(const std::string& path) {
   std::filesystem::create_directories(std::filesystem::u8path(path),
                                       error_code);
   if (error_code) {
-    assert(error_code.category() == std::system_category());
-    return ErrnoToCanonicalStatus(
-        error_code.value(),
-        absl::StrFormat("Failed to create directory '%s'", path));
+    return ErrorCodeToCanonicalStatus(
+        error_code, absl::StrFormat("Failed to create directory '%s'", path));
   }
   return absl::OkStatus();
 }

--- a/common/path.cc
+++ b/common/path.cc
@@ -470,8 +470,7 @@ absl::StatusOr<FILE*> OpenFile(const std::string& path, const char* mode) {
 #endif
   if (!file) {
     int err = errno;
-    return ErrnoToCanonicalStatus(
-        err, absl::StrFormat("Failed to open file '%s'", path));
+    return ErrnoToCanonicalStatus(err, "Failed to open file '%s'", path);
   }
   return file;
 }
@@ -914,8 +913,7 @@ absl::Status GetStats(const std::string& path, Stats* stats) {
   if (!result) {
     int err = errno;
     *stats = Stats();
-    return ErrnoToCanonicalStatus(err,
-                                  absl::StrFormat("Failed to stat '%s'", path));
+    return ErrnoToCanonicalStatus(err, "Failed to stat '%s'", path);
   }
 
   stats->mode = os_stats.st_mode;
@@ -973,13 +971,9 @@ absl::Status CreateSymlink(const std::string& target,
     std::filesystem::create_directory_symlink(target_u8, link_path_u8,
                                               error_code);
   }
-  if (error_code) {
-    return ErrorCodeToCanonicalStatus(
-        error_code,
-        absl::StrFormat("Failed to create symlink '%s' with target '%s'",
-                        link_path, target));
-  }
-  return absl::OkStatus();
+  return ErrorCodeToCanonicalStatus(
+      error_code, "Failed to create symlink '%s' with target '%s'", link_path,
+      target);
 }
 
 absl::StatusOr<std::string> GetSymlinkTarget(const std::string& link_path) {
@@ -988,8 +982,8 @@ absl::StatusOr<std::string> GetSymlinkTarget(const std::string& link_path) {
   std::filesystem::path symlink_target =
       std::filesystem::read_symlink(link_path_u8, error_code);
   if (error_code) {
-    return ErrorCodeToCanonicalStatus(
-        error_code, absl::StrFormat("Failed to read symlink '%s'", link_path));
+    return ErrorCodeToCanonicalStatus(error_code, "Failed to read symlink '%s'",
+                                      link_path);
   }
   return symlink_target.u8string();
 }
@@ -1012,22 +1006,16 @@ bool Exists(const std::string& path) {
 absl::Status CreateDir(const std::string& path) {
   std::error_code error_code;
   std::filesystem::create_directory(std::filesystem::u8path(path), error_code);
-  if (error_code) {
-    return ErrorCodeToCanonicalStatus(
-        error_code, absl::StrFormat("Failed to create directory '%s'", path));
-  }
-  return absl::OkStatus();
+  return ErrorCodeToCanonicalStatus(error_code,
+                                    "Failed to create directory '%s'", path);
 }
 
 absl::Status CreateDirRec(const std::string& path) {
   std::error_code error_code;
   std::filesystem::create_directories(std::filesystem::u8path(path),
                                       error_code);
-  if (error_code) {
-    return ErrorCodeToCanonicalStatus(
-        error_code, absl::StrFormat("Failed to create directory '%s'", path));
-  }
-  return absl::OkStatus();
+  return ErrorCodeToCanonicalStatus(error_code,
+                                    "Failed to create directory '%s'", path);
 }
 
 absl::Status RenameFile(const std::string& from_path,

--- a/common/path.h
+++ b/common/path.h
@@ -99,11 +99,14 @@ enum class FolderId {
 
 // Returns the Windows known folder path for the given |folder_id|.
 absl::Status GetKnownFolderPath(FolderId folder_id, std::string* path);
-
-// Expands environment path variables like %APPDATA%. Variables are matched
-// case invariantly. Unknown environment variables are not changed.
-absl::Status ExpandEnvironmentPathVariables(std::string* path);
 #endif
+
+// Expands environment path variables like %APPDATA% on Windows or ~ on Linux.
+// On Windows, variables are matched case invariantly. Unknown environment
+// variables are not changed.
+// On Linux, performs a shell-like expansion. Returns an error if multiple
+// results would be returned, e.g. from *.txt.
+absl::Status ExpandPathVariables(std::string* path);
 
 // Returns the environment variable with given |name| in |value|.
 // Returns a NotFound error and sets |value| to an empty string if the variable

--- a/data_store/disk_data_store.cc
+++ b/data_store/disk_data_store.cc
@@ -84,6 +84,9 @@ DiskDataStore::DiskDataStore(unsigned int depth, std::string cache_root_dir,
 absl::StatusOr<std::unique_ptr<DiskDataStore>> DiskDataStore::Create(
     unsigned int depth, std::string cache_root_dir, bool create_dirs,
     SystemClock* clock) {
+  // Resolve e.g. ~.
+  RETURN_IF_ERROR(path::ExpandPathVariables(&cache_root_dir),
+                  "Failed to expand cache dir '%s'", cache_root_dir);
   std::unique_ptr<DiskDataStore> store = absl::WrapUnique(
       new DiskDataStore(depth, std::move(cache_root_dir), create_dirs, clock));
   if (create_dirs) {

--- a/manifest/content_id.cc
+++ b/manifest/content_id.cc
@@ -78,7 +78,7 @@ bool ContentId::FromHexString(const std::string& str,
   std::string* hash = content_id->mutable_blake3_sum_160();
   hash->clear();
   hash->reserve(kHashSize);
-  for (int n = 0; n < str.size(); n += 2) {
+  for (size_t n = 0; n < str.size(); n += 2) {
     int high = HexToInt(str[n]);
     int low = HexToInt(str[n + 1]);
     if (high == -1 || low == -1) {

--- a/manifest/manifest_iterator.cc
+++ b/manifest/manifest_iterator.cc
@@ -79,7 +79,7 @@ absl::Status ManifestIterator::Open(const std::string& manifest_file) {
     std::string msg =
         absl::StrFormat("failed to open file '%s' for reading", manifest_file);
     if (errno) {
-      status_ = ErrnoToCanonicalStatus(errno, msg);
+      status_ = ErrnoToCanonicalStatus(errno, "%s", msg);
     } else {
       status_ = absl::UnknownError(msg);
     }


### PR DESCRIPTION
Fixes a couple of issues with the FUSE:
- Creates the mount directory if it does not exist.
  This assumes the mount dir to be the last arg. Ideally, we'd parse the
  command line and then create the directory, but unfortunately
  fuse_parse_cmdline already verifies that the dir exists.
- Expands the cache_dir (e.g. ~).
- Fixes a compile issue in manifest_iterator.
