### PR TITLE
[cdc_stream] Append errors from netstart to status

### DIFF
--- a/asset_stream_manager/multi_session.cc
+++ b/asset_stream_manager/multi_session.cc
@@ -445,7 +445,7 @@ absl::Status MultiSession::Initialize() {
       ports,
       PortManager::FindAvailableLocalPorts(kAssetStreamPortFirst,
                                            kAssetStreamPortLast, "127.0.0.1",
-                                           process_factory_, true),
+                                           process_factory_),
       "Failed to find an available local port in the range [%d, %d]",
       kAssetStreamPortFirst, kAssetStreamPortLast);
   assert(!ports.empty());

--- a/asset_stream_manager/session.cc
+++ b/asset_stream_manager/session.cc
@@ -76,7 +76,7 @@ absl::Status Session::Start(int local_port, int first_remote_port,
       ports,
       PortManager::FindAvailableRemotePorts(
           first_remote_port, last_remote_port, "127.0.0.1", process_factory_,
-          &remote_util_, kInstanceConnectionTimeoutSec, true),
+          &remote_util_, kInstanceConnectionTimeoutSec),
       "Failed to find an available remote port in the range [%d, %d]",
       first_remote_port, last_remote_port);
   assert(!ports.empty());

--- a/cdc_stream/main.cc
+++ b/cdc_stream/main.cc
@@ -135,6 +135,10 @@ int main(int argc, char* argv[]) {
 
     status = client.StartSession(src_dir, user_host, ssh_port, mount_dir,
                                  ssh_command, scp_command);
+    if (status.ok()) {
+      LOG_INFO("Started streaming directory '%s' to '%s:%s'", src_dir,
+               user_host, mount_dir);
+    }
   } else /* if (command == "stop") */ {
     if (args.size() < 3) {
       LOG_ERROR(
@@ -147,6 +151,9 @@ int main(int argc, char* argv[]) {
     if (!ParseUserHostDir(args[2], &user_host, &mount_dir)) return 1;
 
     status = client.StopSession(user_host, mount_dir);
+    if (status.ok()) {
+      LOG_INFO("Stopped streaming session to '%s:%s'", user_host, mount_dir);
+    }
   }
 
   if (!status.ok()) {

--- a/common/port_manager.h
+++ b/common/port_manager.h
@@ -71,12 +71,10 @@ class PortManager {
   // forwarding on the local workstation.
   // |ip| is the IP address to filter by.
   // |process_factory| is used to create a netstat process.
-  // |forward_output_to_log| determines whether the stderr of netstat is
-  // forwarded to the logs. Returns ResourceExhaustedError if no port is
-  // available.
+  // Returns ResourceExhaustedError if no port is available.
   static absl::StatusOr<std::unordered_set<int>> FindAvailableLocalPorts(
       int first_port, int last_port, const char* ip,
-      ProcessFactory* process_factory, bool forward_output_to_log);
+      ProcessFactory* process_factory);
 
   // Finds available ports in the range [first_port, last_port] for port
   // forwarding on the instance.
@@ -84,13 +82,11 @@ class PortManager {
   // |process_factory| is used to create a netstat process.
   // |remote_util| is used to connect to the instance.
   // |timeout_sec| is the connection timeout in seconds.
-  // |forward_output_to_log| determines whether the stderr of netstat is
-  // forwarded to the logs. Returns a DeadlineExceeded error if the timeout is
-  // exceeded. Returns ResourceExhaustedError if no port is available.
+  // Returns a DeadlineExceeded error if the timeout is exceeded.
+  // Returns ResourceExhaustedError if no port is available.
   static absl::StatusOr<std::unordered_set<int>> FindAvailableRemotePorts(
       int first_port, int last_port, const char* ip,
       ProcessFactory* process_factory, RemoteUtil* remote_util, int timeout_sec,
-      bool forward_output_to_log,
       SteadyClock* steady_clock = DefaultSteadyClock::GetInstance());
 
  private:

--- a/common/port_manager_test.cc
+++ b/common/port_manager_test.cc
@@ -219,7 +219,7 @@ TEST_F(PortManagerTest, FindAvailableLocalPortsSuccess) {
 
   absl::StatusOr<std::unordered_set<int>> ports =
       PortManager::FindAvailableLocalPorts(kFirstPort, kLastPort, "127.0.0.1",
-                                           &process_factory_, true);
+                                           &process_factory_);
   ASSERT_OK(ports);
   EXPECT_EQ(ports->size(), kNumPorts - 1);
   for (int port = kFirstPort + 1; port <= kLastPort; ++port) {
@@ -237,7 +237,7 @@ TEST_F(PortManagerTest, FindAvailableLocalPortsFailsNoPorts) {
 
   absl::StatusOr<std::unordered_set<int>> ports =
       PortManager::FindAvailableLocalPorts(kFirstPort, kLastPort, "127.0.0.1",
-                                           &process_factory_, true);
+                                           &process_factory_);
   EXPECT_TRUE(absl::IsResourceExhausted(ports.status()));
   EXPECT_TRUE(absl::StrContains(ports.status().message(),
                                 "No port available in range"));
@@ -252,7 +252,7 @@ TEST_F(PortManagerTest, FindAvailableRemotePortsSuccess) {
   absl::StatusOr<std::unordered_set<int>> ports =
       PortManager::FindAvailableRemotePorts(kFirstPort, kLastPort, "0.0.0.0",
                                             &process_factory_, &remote_util_,
-                                            kTimeoutSec, true);
+                                            kTimeoutSec);
   ASSERT_OK(ports);
   EXPECT_EQ(ports->size(), kNumPorts - 1);
   for (int port = kFirstPort + 1; port <= kLastPort; ++port) {
@@ -271,7 +271,7 @@ TEST_F(PortManagerTest, FindAvailableRemotePortsFailsNoPorts) {
   absl::StatusOr<std::unordered_set<int>> ports =
       PortManager::FindAvailableRemotePorts(kFirstPort, kLastPort, "0.0.0.0",
                                             &process_factory_, &remote_util_,
-                                            kTimeoutSec, true);
+                                            kTimeoutSec);
   EXPECT_TRUE(absl::IsResourceExhausted(ports.status()));
   EXPECT_TRUE(absl::StrContains(ports.status().message(),
                                 "No port available in range"));


### PR DESCRIPTION
So far, errors from the remote netstat process would only be logged in the asset stream service, for instance when SSH auth failed. However, the errors were not shown to the client, and that's the most important thing.

Also adds some feedback to cdc_stream in case of success.