### PR TITLE
Expand path variables for sync destination

### DIFF
--- a/cdc_rsync/file_finder_and_sender.cc
+++ b/cdc_rsync/file_finder_and_sender.cc
@@ -100,14 +100,14 @@ FileFinderAndSender::FileFinderAndSender(PathFilter* path_filter,
       recursive_(recursive),
       relative_(relative),
       request_size_threshold_(request_byte_threshold) {
-  // (internal): Support / instead of \ in the source folder.
+  // Support / instead of \ in the source folder.
   path::FixPathSeparators(&sources_dir_);
 }
 
 FileFinderAndSender::~FileFinderAndSender() = default;
 
 absl::Status FileFinderAndSender::FindAndSendFiles(std::string source) {
-  // (internal): Support / instead of \ in sources.
+  // Support / instead of \ in sources.
   path::FixPathSeparators(&source);
   // Special case, "." and ".." should not specify the directory, but the files
   // inside this directory!

--- a/cdc_rsync_server/cdc_rsync_server.cc
+++ b/cdc_rsync_server/cdc_rsync_server.cc
@@ -303,12 +303,19 @@ absl::Status CdcRsyncServer::HandleSetOptions() {
   existing_ = request.existing();
   copy_dest_ = request.copy_dest();
 
-  // (internal): Support \ instead of / in destination folders.
+  // Support \ instead of / in destination folders.
   path::FixPathSeparators(&destination_);
   path::EnsureEndsWithPathSeparator(&destination_);
   if (!copy_dest_.empty()) {
     path::FixPathSeparators(&copy_dest_);
     path::EnsureEndsWithPathSeparator(&copy_dest_);
+  }
+
+  // Expand e.g. ~.
+  status = path::ExpandPathVariables(&destination_);
+  if (!status.ok()) {
+    return WrapStatus(status, "Failed to expand destination '%s'",
+                      destination_);
   }
 
   assert(path_filter_.IsEmpty());

--- a/common/file_watcher_win.cc
+++ b/common/file_watcher_win.cc
@@ -80,7 +80,7 @@ class AsyncFileWatcher {
         files_changed_cb_(std::move(files_changed_cb)),
         dir_recreated_cb_(std::move(dir_recreated_cb)),
         timeout_ms_(timeout_ms) {
-    // (internal): Check whether ReadDirectoryChangesExW is available.
+    // Check whether ReadDirectoryChangesExW is available.
     // It requires Windows 10, version 1709, released October 17, 2017, or
     // corresponding Windows Server versions.
     if (!enforceLegacyReadDirectoryChangesForTesting) {

--- a/common/file_watcher_win.cc
+++ b/common/file_watcher_win.cc
@@ -80,9 +80,9 @@ class AsyncFileWatcher {
         files_changed_cb_(std::move(files_changed_cb)),
         dir_recreated_cb_(std::move(dir_recreated_cb)),
         timeout_ms_(timeout_ms) {
-    // Check whether ReadDirectoryChangesExW is available.
-    // It requires Windows 10, version 1709, released October 17, 2017, or
-    // corresponding Windows Server versions.
+    // Check whether ReadDirectoryChangesExW is available. It requires Windows
+    // 10, version 1709, released October 17, 2017, or Corresponding Windows
+    // Server versions.
     if (!enforceLegacyReadDirectoryChangesForTesting) {
       read_directory_changes_ex_ =
           reinterpret_cast<decltype(ReadDirectoryChangesExW)*>(::GetProcAddress(

--- a/common/remote_util.cc
+++ b/common/remote_util.cc
@@ -119,7 +119,7 @@ ProcessStartInfo RemoteUtil::BuildProcessStartInfoForSsh(
 
 ProcessStartInfo RemoteUtil::BuildProcessStartInfoForSshPortForward(
     int local_port, int remote_port, bool reverse) {
-  // (internal): Usually, one would pass in -N here, but this makes the
+  // Usually, one would pass in -N here, but this makes the
   // connection terribly slow! As a workaround, don't use -N (will open a
   // shell), but simply eat the output.
   ProcessStartInfo si = BuildProcessStartInfoForSshInternal(

--- a/common/remote_util.cc
+++ b/common/remote_util.cc
@@ -119,9 +119,9 @@ ProcessStartInfo RemoteUtil::BuildProcessStartInfoForSsh(
 
 ProcessStartInfo RemoteUtil::BuildProcessStartInfoForSshPortForward(
     int local_port, int remote_port, bool reverse) {
-  // Usually, one would pass in -N here, but this makes the
-  // connection terribly slow! As a workaround, don't use -N (will open a
-  // shell), but simply eat the output.
+  // Usually, one would pass in -N here, but this makes the connection terribly
+  // slow! As a workaround, don't use -N (will open a shell), but simply eat the
+  // output.
   ProcessStartInfo si = BuildProcessStartInfoForSshInternal(
       GetPortForwardingArg(local_port, remote_port, reverse) + "-n ", "");
   si.stdout_handler = [](const void*, size_t) { return absl::OkStatus(); };

--- a/manifest/manifest_updater_test.cc
+++ b/manifest/manifest_updater_test.cc
@@ -613,7 +613,7 @@ TEST_F(ManifestUpdaterTest, UpdateAll_LargeIntermediateIndirectDirAssets) {
   cfg_.src_dir = path::Join(base_dir_, "non_empty");
   ManifestUpdater updater(&data_store_, cfg_);
 
-  // (internal): Run UpdateAll() with intermediate manifest push. The push
+  // Run UpdateAll() with intermediate manifest push. The push
   // causes a Flush() call to the manifest builder, which pushes some assets to
   // indirect lists. This used to invalidate pointers and cause asserts to
   // trigger.

--- a/manifest/manifest_updater_test.cc
+++ b/manifest/manifest_updater_test.cc
@@ -613,10 +613,9 @@ TEST_F(ManifestUpdaterTest, UpdateAll_LargeIntermediateIndirectDirAssets) {
   cfg_.src_dir = path::Join(base_dir_, "non_empty");
   ManifestUpdater updater(&data_store_, cfg_);
 
-  // Run UpdateAll() with intermediate manifest push. The push
-  // causes a Flush() call to the manifest builder, which pushes some assets to
-  // indirect lists. This used to invalidate pointers and cause asserts to
-  // trigger.
+  // Run UpdateAll() with intermediate manifest push. The push causes a Flush()
+  // call to the manifest builder, which pushes some assets to indirect lists.
+  // This used to invalidate pointers and cause asserts to trigger.
   EXPECT_OK(updater.UpdateAll(&file_chunks_, [](const ContentIdProto&) {}));
 }
 


### PR DESCRIPTION
Running commands like `cdc_rsync C:\assets\* host:~/assets -vr` would create a directory called `~assets`. This CL expands path variables properly.