### PR TITLE
Improve create_release workflow

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,6 +1,12 @@
 name: Create Release
 
-on: [push]
+on:
+  push:
+    # Note: It's branch main OR tags v*, not AND! Tags are not per-branch.
+    branches:
+      - main
+    tags:
+      - "v*"
 
 jobs:
   Build-And-Test-Linux:
@@ -86,16 +92,33 @@ jobs:
     runs-on: ubuntu-latest
     needs: [Build-And-Test-Windows, Build-And-Test-Linux]
     steps:
+      - name: Test
+        run: echo '${{ toJSON(github) }}'
+
       - name: Download artifacts
         uses: actions/download-artifact@v3
 
       - name: Zip binaries
-        run: zip -j binaries_x64.zip Windows-Artifacts/* Linux-Artifacts/*
-      
-      - uses: "marvinpinto/action-automatic-releases@latest"
+        run: |
+          # The ref resolves to "main" for latest and e.g. "v0.1.0" for tagged.
+          BINARIES_ZIP_NAME=cdc-file-transfer-binaries-${GITHUB_REF#refs/*/}-x64.zip
+          echo "BINARIES_ZIP_NAME=$BINARIES_ZIP_NAME" >> $GITHUB_ENV
+          zip -j $BINARIES_ZIP_NAME Windows-Artifacts/* Linux-Artifacts/*
+
+      - name: Publish latest release
+        if: "!startsWith(github.ref, 'refs/tags/v')"
+        uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"
           prerelease: true
           title: "Development Build"
-          files: binaries_x64.zip
+          files: ${{ env.BINARIES_ZIP_NAME }}
+
+      - name: Publish tagged release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+          files: ${{ env.BINARIES_ZIP_NAME }}


### PR DESCRIPTION
Modifies the create_release workflow in 2 ways:
- It only runs now if something is pushed to main.
- It creates a tagged release if a tag is pushed.

To create a tagged release, run e.g.
  git tag -a v0.1.0 -m "Release 0.1.0" git push origin v0.1.0