### PR TITLE
Fix possible indefinite loop in FileWatcherTest

### DIFF
--- a/common/file_watcher_win_test.cc
+++ b/common/file_watcher_win_test.cc
@@ -140,7 +140,11 @@ class FileWatcherParameterizedTest : public ::testing::TestWithParam<bool> {
 
     // Wait for events, until they are processed.
     while (modified_files.size() < number_of_files) {
-      EXPECT_TRUE(WaitForChange());
+      if (!WaitForChange()) {
+        LOG_ERROR("No change detected after %s",
+                  absl::FormatDuration(kWaitTimeout));
+        return modified_files;
+      }
       for (const auto& [path, info] : watcher_.GetModifiedFiles())
         modified_files.insert_or_assign(path, info);
     }


### PR DESCRIPTION
The test
  FileWatcherTest/FileWatcherParameterizedTest.RecreateWatchedDir/ReadDirectoryChangesExW
is flaky. This CL doesn't fix the root cause, but it fixes the indefinite spin in GetChangedFiles when there is no file change.