### PR TITLE
[cdc_rsync] [cdc_stream] Remove SSH port argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,14 +167,34 @@ scp somefile.txt user@linux.device.com:
 Here, `user` is the Linux user and `linux.device.com` is the Linux host to
 SSH into or copy the file to.
 
-If `ssh.exe` or `scp.exe` cannot be found, or if additional arguments are
-required, it is recommended to set the environment variables `CDC_SSH_COMMAND`
-and `CDC_SCP_COMMAND`. The following example specifies a custom path to the SSH
-and SCP binaries, a custom SSH config file, a key file and a known hosts file:
+If additional arguments are required, it is recommended to provide an SSH config
+file. By default, both `ssh.exe` and `scp.exe` use the file at
+`%USERPROFILE%\.ssh\config` on Windows, if it exists. A possible config file
+that sets a username, a port, an identity file and a known host file could look
+as follows:
 ```
-set CDC_SSH_COMMAND="C:\path with space\to\ssh.exe" -F C:\path\to\ssh_config -i C:\path\to\id_rsa -oStrictHostKeyChecking=yes -oUserKnownHostsFile="""C:\path\to\known_hosts"""
-set CDC_SCP_COMMAND="C:\path with space\to\scp.exe" -F C:\path\to\ssh_config -i C:\path\to\id_rsa -oStrictHostKeyChecking=yes -oUserKnownHostsFile="""C:\path\to\known_hosts"""
+Host linux_device
+	HostName linux.device.com
+	User user
+	Port 12345
+	IdentityFile C:\path\to\id_rsa
+	UserKnownHostsFile C:\path\to\known_hosts
 ```
+If `ssh.exe` or `scp.exe` cannot be found, you can specify the full paths via
+the command line arguments `--ssh-command` and `--scp-command` for `cdc_rsync`
+and `cdc_stream start` (see below), or set the environment variables
+`CDC_SSH_COMMAND` and `CDC_SCP_COMMAND`, e.g.
+```
+set CDC_SSH_COMMAND="C:\path with space\to\ssh.exe"
+set CDC_SCP_COMMAND="C:\path with space\to\scp.exe"
+```
+Note that you can also specify SSH configuration via the environment variables
+instead of using a config file:
+```
+set CDC_SSH_COMMAND=C:\path\to\ssh.exe -p 12345 -i C:\path\to\id_rsa -oUserKnownHostsFile=C:\path\to\known_hosts
+set CDC_SCP_COMMAND=C:\path\to\scp.exe -P 12345 -i C:\path\to\id_rsa -oUserKnownHostsFile=C:\path\to\known_hosts
+```
+Note the small `-p` for `ssh.exe` and the capital `-P` for `scp.exe`.
 
 #### Google Specific
 

--- a/cdc_rsync/cdc_rsync_client.cc
+++ b/cdc_rsync/cdc_rsync_client.cc
@@ -99,9 +99,9 @@ CdcRsyncClient::CdcRsyncClient(const Options& options,
                                std::string user_host, std::string destination)
     : options_(options),
       sources_(std::move(sources)),
-      user_host_(std::move(user_host)),
       destination_(std::move(destination)),
-      remote_util_(options.verbosity, options.quiet, &process_factory_,
+      remote_util_(std::move(user_host), options.verbosity, options.quiet,
+                   &process_factory_,
                    /*forward_output_to_log=*/false),
       port_manager_("cdc_rsync_ports_f77bcdfe-368c-4c45-9f01-230c5e7e2132",
                     kForwardPortFirst, kForwardPortLast, &process_factory_,
@@ -122,9 +122,6 @@ CdcRsyncClient::~CdcRsyncClient() {
 }
 
 absl::Status CdcRsyncClient::Run() {
-  // Initialize |remote_util_|.
-  remote_util_.SetUserHostAndPort(user_host_, options_.port);
-
   // Start the server process.
   absl::Status status = StartServer();
   if (HasTag(status, Tag::kDeployServer)) {

--- a/cdc_rsync/cdc_rsync_client.h
+++ b/cdc_rsync/cdc_rsync_client.h
@@ -36,7 +36,6 @@ class ZstdStream;
 class CdcRsyncClient {
  public:
   struct Options {
-    int port = RemoteUtil::kDefaultSshPort;
     bool delete_ = false;
     bool recursive = false;
     int verbosity = 0;
@@ -118,7 +117,6 @@ class CdcRsyncClient {
 
   Options options_;
   std::vector<std::string> sources_;
-  const std::string user_host_;
   const std::string destination_;
   WinProcessFactory process_factory_;
   RemoteUtil remote_util_;

--- a/cdc_rsync/main.cc
+++ b/cdc_rsync/main.cc
@@ -75,9 +75,9 @@ ReturnCode TagToMessage(cdc_ft::Tag tag,
     case cdc_ft::Tag::kConnectionTimeout:
       // Server connection timed out. SSH probably stale.
       *msg = absl::StrFormat(
-          "Server connection timed out. Verify that host '%s' and port '%i' "
-          "are correct, or specify a larger timeout with --contimeout.",
-          params.user_host, params.options.port);
+          "Server connection timed out. Verify that the host '%s' "
+          "is correct, or specify a larger timeout with --contimeout.",
+          params.user_host);
       return ReturnCode::kConnectionTimeout;
 
     case cdc_ft::Tag::kCount:

--- a/cdc_rsync/params.cc
+++ b/cdc_rsync/params.cc
@@ -72,10 +72,10 @@ Options:
     --existing            Skip creating new files on instance
     --copy-dest dir       Use files from dir as sync base if files are missing
     --ssh-command         Path and arguments of ssh command to use, e.g.
-                          C:\path\to\ssh.exe -p 1234 -F config -i id_rsa -oStrictHostKeyChecking=yes -oUserKnownHostsFile="""known_hosts"""
+                          "C:\path\to\ssh.exe -p 12345 -i id_rsa -oUserKnownHostsFile=known_hosts"
                           Can also be specified by the CDC_SSH_COMMAND environment variable.
     --scp-command         Path and arguments of scp command to use, e.g.
-                          C:\path\to\scp.exe -P 1234 -F config -i id_rsa -oStrictHostKeyChecking=yes -oUserKnownHostsFile="""known_hosts"""
+                          "C:\path\to\scp.exe -P 12345 -i id_rsa -oUserKnownHostsFile=known_hosts"
                           Can also be specified by the CDC_SCP_COMMAND environment variable.
 -h  --help                Help for cdc_rsync
 )";

--- a/cdc_rsync/params.cc
+++ b/cdc_rsync/params.cc
@@ -51,8 +51,6 @@ Parameters:
   destination             Remote destination directory
 
 Options:
-    --ip string           Gamelet IP. Required.
-    --port number         SSH port to use. Required.
     --contimeout sec      Gamelet connection timeout in seconds (default: 10)
 -q, --quiet               Quiet mode, only print errors
 -v, --verbose             Increase output verbosity
@@ -74,10 +72,10 @@ Options:
     --existing            Skip creating new files on instance
     --copy-dest dir       Use files from dir as sync base if files are missing
     --ssh-command         Path and arguments of ssh command to use, e.g.
-                          C:\path\to\ssh.exe -F config -i id_rsa -oStrictHostKeyChecking=yes -oUserKnownHostsFile="""known_hosts"""
+                          C:\path\to\ssh.exe -p 1234 -F config -i id_rsa -oStrictHostKeyChecking=yes -oUserKnownHostsFile="""known_hosts"""
                           Can also be specified by the CDC_SSH_COMMAND environment variable.
     --scp-command         Path and arguments of scp command to use, e.g.
-                          C:\path\to\scp.exe -F config -i id_rsa -oStrictHostKeyChecking=yes -oUserKnownHostsFile="""known_hosts"""
+                          C:\path\to\scp.exe -P 1234 -F config -i id_rsa -oStrictHostKeyChecking=yes -oUserKnownHostsFile="""known_hosts"""
                           Can also be specified by the CDC_SCP_COMMAND environment variable.
 -h  --help                Help for cdc_rsync
 )";
@@ -164,13 +162,6 @@ bool LoadFilesFrom(const std::string& files_from,
 
 OptionResult HandleParameter(const std::string& key, const char* value,
                              Parameters* params, bool* help) {
-  if (key == "port") {
-    if (value) {
-      params->options.port = atoi(value);
-    }
-    return OptionResult::kConsumedKeyValue;
-  }
-
   if (key == "delete") {
     params->options.delete_ = true;
     return OptionResult::kConsumedKey;
@@ -299,11 +290,6 @@ bool ValidateParameters(const Parameters& params, bool help) {
 
   if (params.options.delete_ && !params.options.recursive) {
     PrintError("--delete does not work without --recursive (-r).");
-    return false;
-  }
-
-  if (params.options.port <= 0 || params.options.port > UINT16_MAX) {
-    PrintError("--port must specify a valid port");
     return false;
   }
 

--- a/cdc_rsync/params_test.cc
+++ b/cdc_rsync/params_test.cc
@@ -97,7 +97,6 @@ class ParamsTest : public ::testing::Test {
 TEST_F(ParamsTest, ParseSucceedsDefaults) {
   const char* argv[] = {"cdc_rsync.exe", kSrc, kUserHostDst, NULL};
   EXPECT_TRUE(Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
-  EXPECT_EQ(RemoteUtil::kDefaultSshPort, parameters_.options.port);
   EXPECT_FALSE(parameters_.options.delete_);
   EXPECT_FALSE(parameters_.options.recursive);
   EXPECT_EQ(0, parameters_.options.verbosity);
@@ -143,13 +142,6 @@ TEST_F(ParamsTest, ParseFailsOnCompressLevelEqualsNoValue) {
   EXPECT_FALSE(
       Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
   ExpectError(NeedsValueError("compress-level"));
-}
-
-TEST_F(ParamsTest, ParseFailsOnPortEqualsNoValue) {
-  const char* argv[] = {"cdc_rsync.exe", "--port=", kSrc, kUserHostDst, NULL};
-  EXPECT_FALSE(
-      Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
-  ExpectError(NeedsValueError("port"));
 }
 
 TEST_F(ParamsTest, ParseFailsOnContimeoutEqualsNoValue) {
@@ -285,13 +277,18 @@ TEST_F(ParamsTest, ParseFailsOnUnknownKey) {
 }
 
 TEST_F(ParamsTest, ParseSucceedsWithSupportedKeyValue) {
-  const char* argv[] = {
-      "cdc_rsync.exe", "--compress-level", "11", "--contimeout", "99", "--port",
-      "4086",          "--copy-dest=dest", kSrc, kUserHostDst,   NULL};
+  const char* argv[] = {"cdc_rsync.exe",
+                        "--compress-level",
+                        "11",
+                        "--contimeout",
+                        "99",
+                        "--copy-dest=dest",
+                        kSrc,
+                        kUserHostDst,
+                        NULL};
   EXPECT_TRUE(Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
   EXPECT_EQ(parameters_.options.compress_level, 11);
   EXPECT_EQ(parameters_.options.connection_timeout_sec, 99);
-  EXPECT_EQ(parameters_.options.port, 4086);
   EXPECT_EQ(parameters_.options.copy_dest, "dest");
   ExpectNoError();
 }
@@ -302,13 +299,6 @@ TEST_F(ParamsTest, ParseSucceedsWithSupportedKeyValueWithoutEqualityForChars) {
   EXPECT_TRUE(Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
   EXPECT_EQ(parameters_.options.copy_dest, "dest");
   ExpectNoError();
-}
-
-TEST_F(ParamsTest, ParseFailsOnInvalidPort) {
-  const char* argv[] = {"cdc_rsync.exe", "--port=0", kSrc, kUserHostDst, NULL};
-  EXPECT_FALSE(
-      Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
-  ExpectError("--port must specify a valid port");
 }
 
 TEST_F(ParamsTest, ParseFailsOnDeleteNeedsRecursive) {

--- a/cdc_stream/asset_stream_config.cc
+++ b/cdc_stream/asset_stream_config.cc
@@ -135,14 +135,6 @@ void AssetStreamConfig::RegisterCommandLineFlags(lyra::command& cmd,
           .name("--dev-user-host")
           .help("Username and host to stream to. See also --dev-src-dir."));
 
-  dev_target_.ssh_port = RemoteUtil::kDefaultSshPort;
-  cmd.add_argument(
-      lyra::opt(dev_target_.ssh_port, "port")
-          .name("--dev-ssh-port")
-          .help("SSH port to use for the connection to the host, default: " +
-                std::to_string(RemoteUtil::kDefaultSshPort) +
-                ". See also --dev-src-dir."));
-
   cmd.add_argument(
       lyra::opt(dev_target_.ssh_command, "cmd")
           .name("--dev-ssh-command")
@@ -245,7 +237,6 @@ std::string AssetStreamConfig::ToString() {
      << session_cfg_.file_change_wait_duration_ms << std::endl;
   ss << "dev-src-dir                  = " << dev_src_dir_ << std::endl;
   ss << "dev-user-host                = " << dev_target_.user_host << std::endl;
-  ss << "dev-ssh-port                 = " << dev_target_.ssh_port << std::endl;
   ss << "dev-ssh-command              = " << dev_target_.ssh_command
      << std::endl;
   ss << "dev-scp-command              = " << dev_target_.scp_command

--- a/cdc_stream/local_assets_stream_manager_client.cc
+++ b/cdc_stream/local_assets_stream_manager_client.cc
@@ -36,13 +36,12 @@ LocalAssetsStreamManagerClient::LocalAssetsStreamManagerClient(
 LocalAssetsStreamManagerClient::~LocalAssetsStreamManagerClient() = default;
 
 absl::Status LocalAssetsStreamManagerClient::StartSession(
-    const std::string& src_dir, const std::string& user_host, uint16_t ssh_port,
+    const std::string& src_dir, const std::string& user_host,
     const std::string& mount_dir, const std::string& ssh_command,
     const std::string& scp_command) {
   StartSessionRequest request;
   request.set_workstation_directory(src_dir);
   request.set_user_host(user_host);
-  request.set_port(ssh_port);
   request.set_mount_dir(mount_dir);
   request.set_ssh_command(ssh_command);
   request.set_scp_command(scp_command);

--- a/cdc_stream/local_assets_stream_manager_client.h
+++ b/cdc_stream/local_assets_stream_manager_client.h
@@ -41,12 +41,11 @@ class LocalAssetsStreamManagerClient {
   // Starting a second session to the same target will stop the first one.
   // |src_dir| is the Windows source directory to stream.
   // |user_host| is the Linux host, formatted as [user@:host].
-  // |ssh_port| is the SSH port to use while connecting to the host.
   // |mount_dir| is the Linux target directory to stream to.
   // |ssh_command| is the ssh command and extra arguments to use.
   // |scp_command| is the scp command and extra arguments to use.
   absl::Status StartSession(const std::string& src_dir,
-                            const std::string& user_host, uint16_t ssh_port,
+                            const std::string& user_host,
                             const std::string& mount_dir,
                             const std::string& ssh_command,
                             const std::string& scp_command);

--- a/cdc_stream/local_assets_stream_manager_service_impl.h
+++ b/cdc_stream/local_assets_stream_manager_service_impl.h
@@ -93,11 +93,10 @@ class LocalAssetsStreamManagerServiceImpl final
 
   // Initializes an ssh connection to a gamelet by calling 'ggp ssh init'.
   // |instance_id| must be set, |project_id|, |organization_id| are optional.
-  // Returns |instance_ip| and |instance_port| (SSH port).
-  absl::Status InitSsh(const std::string& instance_id,
-                       const std::string& project_id,
-                       const std::string& organization_id,
-                       std::string* instance_ip, uint16_t* instance_port);
+  // Returns the instance's IP address.
+  absl::StatusOr<std::string> InitSsh(const std::string& instance_id,
+                                      const std::string& project_id,
+                                      const std::string& organization_id);
 
   const SessionConfig cfg_;
   SessionManager* const session_manager_;

--- a/cdc_stream/session.cc
+++ b/cdc_stream/session.cc
@@ -47,11 +47,11 @@ Session::Session(std::string instance_id, const SessionTarget& target,
       mount_dir_(target.mount_dir),
       cfg_(std::move(cfg)),
       process_factory_(process_factory),
-      remote_util_(cfg_.verbosity, cfg_.quiet, process_factory,
+      remote_util_(target.user_host, cfg_.verbosity, cfg_.quiet,
+                   process_factory,
                    /*forward_output_to_logging=*/true),
       metrics_recorder_(std::move(metrics_recorder)) {
   assert(metrics_recorder_);
-  remote_util_.SetUserHostAndPort(target.user_host, target.ssh_port);
   if (!target.ssh_command.empty()) {
     remote_util_.SetSshCommand(target.ssh_command);
   }

--- a/cdc_stream/session.h
+++ b/cdc_stream/session.h
@@ -36,8 +36,6 @@ class Process;
 struct SessionTarget {
   // SSH username and hostname of the remote target, formed as [user@]host.
   std::string user_host;
-  // Port to use for SSH connections to the remote target.
-  uint16_t ssh_port;
   // Ssh command to use to connect to the remote target.
   std::string ssh_command;
   // Scp command to use to copy files to the remote target.

--- a/cdc_stream/start_command.h
+++ b/cdc_stream/start_command.h
@@ -43,7 +43,6 @@ class StartCommand : public BaseCommand {
 
   int verbosity_ = 0;
   uint16_t service_port_ = 0;
-  uint16_t ssh_port_ = 0;
   std::string ssh_command_;
   std::string scp_command_;
   std::string src_dir_;

--- a/cdc_stream/start_service_command.cc
+++ b/cdc_stream/start_service_command.cc
@@ -140,7 +140,6 @@ absl::Status StartServiceCommand::RunService() {
     request.set_workstation_directory(cfg_.dev_src_dir());
     request.set_user_host(cfg_.dev_target().user_host);
     request.set_mount_dir(cfg_.dev_target().mount_dir);
-    request.set_port(cfg_.dev_target().ssh_port);
     request.set_ssh_command(cfg_.dev_target().ssh_command);
     request.set_scp_command(cfg_.dev_target().scp_command);
     localassetsstreammanager::StartSessionResponse response;

--- a/common/port_manager_test.cc
+++ b/common/port_manager_test.cc
@@ -49,14 +49,14 @@ constexpr char kRemoteNetstatOutFmt[] =
 class PortManagerTest : public ::testing::Test {
  public:
   PortManagerTest()
-      : remote_util_(/*verbosity=*/0, /*quiet=*/false, &process_factory_,
+      : remote_util_(kUserHost, /*verbosity=*/0, /*quiet=*/false,
+                     &process_factory_,
                      /*forward_output_to_log=*/true),
         port_manager_(kGuid, kFirstPort, kLastPort, &process_factory_,
                       &remote_util_, &system_clock_, &steady_clock_) {}
 
   void SetUp() override {
     Log::Initialize(std::make_unique<ConsoleLog>(LogLevel::kInfo));
-    remote_util_.SetUserHostAndPort(kUserHost, kSshPort);
   }
 
   void TearDown() override { Log::Shutdown(); }

--- a/common/remote_util.h
+++ b/common/remote_util.h
@@ -39,14 +39,12 @@ class RemoteUtil {
              ProcessFactory* process_factory, bool forward_output_to_log);
 
   // Sets the SCP command binary path and additional arguments, e.g.
-  //   C:\path\to\scp.exe -p 1234 -F <ssh_config> -i <key_file>
-  //     -oStrictHostKeyChecking=yes -oUserKnownHostsFile="""file"""
+  //   C:\path\to\scp.exe -p 1234 -i <key_file> -oUserKnownHostsFile=known_hosts
   // By default, searches scp.exe on the path environment variables.
   void SetScpCommand(std::string scp_command);
 
   // Sets the SSH command binary path and additional arguments, e.g.
-  //   C:\path\to\ssh.exe -P 1234 -F <ssh_config> -i <key_file>
-  //     -oStrictHostKeyChecking=yes -oUserKnownHostsFile="""file"""
+  //   C:\path\to\ssh.exe -P 1234 -i <key_file> -oUserKnownHostsFile=known_hosts
   // By default, searches ssh.exe on the path environment variables.
   void SetSshCommand(std::string ssh_command);
 

--- a/common/remote_util.h
+++ b/common/remote_util.h
@@ -29,46 +29,38 @@ namespace cdc_ft {
 // Windows-only.
 class RemoteUtil {
  public:
-  static constexpr int kDefaultSshPort = 22;
-
+  // |user_host| is the SSH [user@]host of the remote instance.
   // If |verbosity| is > 0 and |quiet| is false, output from scp, ssh etc.
   // commands is shown.
   // If |quiet| is true, scp, ssh etc. commands use quiet mode.
   // If |forward_output_to_log| is true, process output is forwarded to logging
   // instead of this process's stdout/stderr.
-  RemoteUtil(int verbosity, bool quiet, ProcessFactory* process_factory,
-             bool forward_output_to_log);
-
-  // Sets the SSH username and hostname of the remote instance, as well as the
-  // SSH tunnel port. |user_host| must be of the form [user@]host.
-  void SetUserHostAndPort(std::string user_host, int port);
+  RemoteUtil(std::string user_host, int verbosity, bool quiet,
+             ProcessFactory* process_factory, bool forward_output_to_log);
 
   // Sets the SCP command binary path and additional arguments, e.g.
-  //   C:\path\to\scp.exe -F <ssh_config> -i <key_file>
+  //   C:\path\to\scp.exe -p 1234 -F <ssh_config> -i <key_file>
   //     -oStrictHostKeyChecking=yes -oUserKnownHostsFile="""file"""
   // By default, searches scp.exe on the path environment variables.
   void SetScpCommand(std::string scp_command);
 
   // Sets the SSH command binary path and additional arguments, e.g.
-  //   C:\path\to\ssh.exe -F <ssh_config> -i <key_file>
+  //   C:\path\to\ssh.exe -P 1234 -F <ssh_config> -i <key_file>
   //     -oStrictHostKeyChecking=yes -oUserKnownHostsFile="""file"""
   // By default, searches ssh.exe on the path environment variables.
   void SetSshCommand(std::string ssh_command);
 
   // Copies |source_filepaths| to the remote folder |dest| on the gamelet using
   // scp. If |compress| is true, compressed upload is used.
-  // Must call SetUserHostAndPort before calling this method.
   absl::Status Scp(std::vector<std::string> source_filepaths,
                    const std::string& dest, bool compress);
 
   // Calls 'chmod |mode| |remote_path|' on the gamelet.
-  // Must call SetUserHostAndPort before calling this method.
   absl::Status Chmod(const std::string& mode, const std::string& remote_path,
                      bool quiet = false);
 
   // Runs |remote_command| on the gamelet. The command must be properly escaped.
   // |name| is the name of the command displayed in the logs.
-  // Must call SetUserHostAndPort before calling this method.
   absl::Status Run(std::string remote_command, std::string name);
 
   // Builds an SSH command that executes |remote_command| on the gamelet.
@@ -77,7 +69,6 @@ class RemoteUtil {
   // Builds an SSH command that runs SSH port forwarding to the gamelet, using
   // the given |local_port| and |remote_port|.
   // If |reverse| is true, sets up reverse port forwarding.
-  // Must call SetUserHostAndPort before calling this method.
   ProcessStartInfo BuildProcessStartInfoForSshPortForward(int local_port,
                                                           int remote_port,
                                                           bool reverse);
@@ -85,7 +76,6 @@ class RemoteUtil {
   // Builds an SSH command that executes |remote_command| on the gamelet, using
   // port forwarding with given |local_port| and |remote_port|.
   // If |reverse| is true, sets up reverse port forwarding.
-  // Must call SetUserHostAndPort before calling this method.
   ProcessStartInfo BuildProcessStartInfoForSshPortForwardAndCommand(
       int local_port, int remote_port, bool reverse,
       std::string remote_command);
@@ -117,9 +107,6 @@ class RemoteUtil {
   static std::string QuoteForSsh(const std::string& argument);
 
  private:
-  // Verifies that both |user_host_| and |ssh_port_| are set.
-  absl::Status CheckUserHostPort();
-
   // Common code for BuildProcessStartInfoForSsh*.
   ProcessStartInfo BuildProcessStartInfoForSshInternal(
       std::string forward_arg, std::string remote_command);
@@ -132,7 +119,6 @@ class RemoteUtil {
   std::string scp_command_ = "scp";
   std::string ssh_command_ = "ssh";
   std::string user_host_;
-  int ssh_port_ = kDefaultSshPort;
 };
 
 }  // namespace cdc_ft

--- a/common/remote_util_test.cc
+++ b/common/remote_util_test.cc
@@ -21,9 +21,6 @@
 namespace cdc_ft {
 namespace {
 
-constexpr int kSshPort = 12345;
-constexpr char kSshPortArg[] = "-p 12345";
-
 constexpr char kUserHost[] = "user@example.com";
 constexpr char kUserHostArg[] = "\"user@example.com\"";
 
@@ -39,12 +36,11 @@ constexpr char kCommand[] = "my_command";
 class RemoteUtilTest : public ::testing::Test {
  public:
   RemoteUtilTest()
-      : util_(/*verbosity=*/0, /*quiet=*/false, &process_factory_,
+      : util_(kUserHost, /*verbosity=*/0, /*quiet=*/false, &process_factory_,
               /*forward_output_to_log=*/true) {}
 
   void SetUp() override {
     Log::Initialize(std::make_unique<ConsoleLog>(LogLevel::kInfo));
-    util_.SetUserHostAndPort(kUserHost, kSshPort);
   }
 
   void TearDown() override { Log::Shutdown(); }
@@ -64,31 +60,29 @@ class RemoteUtilTest : public ::testing::Test {
 
 TEST_F(RemoteUtilTest, BuildProcessStartInfoForSsh) {
   ProcessStartInfo si = util_.BuildProcessStartInfoForSsh(kCommand);
-  ExpectContains(si.command, {"ssh", kSshPortArg, kUserHostArg, kCommand});
+  ExpectContains(si.command, {"ssh", kUserHostArg, kCommand});
 }
 
 TEST_F(RemoteUtilTest, BuildProcessStartInfoForSshPortForward) {
   ProcessStartInfo si = util_.BuildProcessStartInfoForSshPortForward(
       kLocalPort, kRemotePort, kRegular);
-  ExpectContains(si.command,
-                 {"ssh", kSshPortArg, kUserHostArg, kPortForwardingArg});
+  ExpectContains(si.command, {"ssh", kUserHostArg, kPortForwardingArg});
 
   si = util_.BuildProcessStartInfoForSshPortForward(kLocalPort, kRemotePort,
                                                     kReverse);
-  ExpectContains(si.command,
-                 {"ssh", kSshPortArg, kUserHostArg, kReversePortForwardingArg});
+  ExpectContains(si.command, {"ssh", kUserHostArg, kReversePortForwardingArg});
 }
 
 TEST_F(RemoteUtilTest, BuildProcessStartInfoForSshPortForwardAndCommand) {
   ProcessStartInfo si = util_.BuildProcessStartInfoForSshPortForwardAndCommand(
       kLocalPort, kRemotePort, kRegular, kCommand);
-  ExpectContains(si.command, {"ssh", kSshPortArg, kUserHostArg,
-                              kPortForwardingArg, kCommand});
+  ExpectContains(si.command,
+                 {"ssh", kUserHostArg, kPortForwardingArg, kCommand});
 
   si = util_.BuildProcessStartInfoForSshPortForwardAndCommand(
       kLocalPort, kRemotePort, kReverse, kCommand);
-  ExpectContains(si.command, {"ssh", kSshPortArg, kUserHostArg,
-                              kReversePortForwardingArg, kCommand});
+  ExpectContains(si.command,
+                 {"ssh", kUserHostArg, kReversePortForwardingArg, kCommand});
 }
 TEST_F(RemoteUtilTest, BuildProcessStartInfoForSshWithCustomCommand) {
   constexpr char kCustomSshCmd[] = "C:\\path\\to\\ssh.exe --fooarg --bararg=42";

--- a/proto/local_assets_stream_manager.proto
+++ b/proto/local_assets_stream_manager.proto
@@ -45,9 +45,6 @@ message StartSessionRequest {
   string user_host = 7;
   // Remote directory where to mount the streamed directory.
   string mount_dir = 8;
-  // SSH port to use while connecting to the remote instance.
-  // Optional, falls back to port 22 (default SSH port).
-  int32 port = 9;
   // SSH command to connect to the remote instance.
   // Optional, falls back to searching ssh.
   string ssh_command = 10;
@@ -55,7 +52,7 @@ message StartSessionRequest {
   // Optional, falls back to searching scp.
   string scp_command = 11;
 
-  reserved 1, 3, 4;
+  reserved 1, 3, 4, 9;
 }
 
 message StartSessionResponse {}


### PR DESCRIPTION
This CL removes the port arguments for both tools.

The port argument can also be specified via the ssh-command and scp-command flags. In fact, if a port is specified by both port flags and ssh/scp commands, they interfere with each other. For ssh, the one specified in ssh-command wins. For scp, the one specified in scp-command wins. To fix this, one would have to parse scp-command and remove the port arg there. Or we could just remove the ssh-port arg. This is what this CL does. Note that if you need a custom port, it's very likely that you also have to define custom ssh and scp commands.