### PR TITLE
Fix build caching

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: bazel-cache
-          key: ${{ runner.os }}-bazel-cache-${{ env.date }}
+          key: ${{ runner.os }}-bazel-cache-fastbuild-${{ env.date }}
 
       - name: Build (fastbuild)
         run: bazel build --config=linux --disk_cache=bazel-cache -- //... -//third_party/...
@@ -55,18 +55,18 @@ jobs:
       - name: Create timestamp
         run: |
           $date = Get-Date -Format "yyyy-MM"
-          echo "date=$date" >> $GITHUB_ENV
+          echo "date=$date" >> $env:GITHUB_ENV
 
       - name: Restore build cache
         uses: actions/cache@v3
         with:
           path: bazel-cache
-          key: ${{ runner.os }}-bazel-cache-${{ env.date }}
+          key: ${{ runner.os }}-bazel-cache-fastbuild-${{ env.date }}
 
-      - name: Build
+      - name: Build (fastbuild)
         run: bazel build --config=windows --disk_cache=bazel-cache //cdc_rsync //cdc_stream //tests_common //tests_cdc_stream //tests_cdc_rsync
 
-      - name: Test
+      - name: Test (fastbuild)
         run: |
           bazel-bin\tests_common\tests_common.exe
           bazel-bin\tests_cdc_stream\tests_cdc_stream.exe

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -26,14 +26,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: bazel-cache
-          key: ${{ runner.os }}-bazel-cache-${{ env.date }}
+          key: ${{ runner.os }}-bazel-cache-opt-${{ env.date }}
 
-      - name: Build
+      - name: Build (opt)
         run: |
           bazel build --config=linux --disk_cache=bazel-cache --compilation_mode=opt --linkopt=-Wl,--strip-all --copt=-fdata-sections --copt=-ffunction-sections --linkopt=-Wl,--gc-sections \
             //cdc_fuse_fs //cdc_rsync_server
 
-      - name: Test
+      - name: Test (opt)
         run: |
           bazel test --config=linux --disk_cache=bazel-cache --compilation_mode=opt --linkopt=-Wl,--strip-all --copt=-fdata-sections --copt=-ffunction-sections --linkopt=-Wl,--gc-sections \
                      --test_output=errors --local_test_jobs=1  \
@@ -64,20 +64,20 @@ jobs:
       - name: Create timestamp
         run: |
           $date = Get-Date -Format "yyyy-MM"
-          echo "date=$date" >> $GITHUB_ENV
+          echo "date=$date" >> $env:GITHUB_ENV
 
       - name: Restore build cache
         uses: actions/cache@v3
         with:
           path: bazel-cache
-          key: ${{ runner.os }}-bazel-cache-${{ env.date }}
+          key: ${{ runner.os }}-bazel-cache-opt-${{ env.date }}
 
-      - name: Build
+      - name: Build (opt)
         run: |
           bazel build --config=windows --disk_cache=bazel-cache --compilation_mode=opt --copt=/GL `
                        //cdc_rsync //cdc_stream //tests_common //tests_cdc_stream //tests_cdc_rsync
 
-      - name: Test
+      - name: Test (opt)
         run: |
           bazel-bin\tests_common\tests_common.exe
           bazel-bin\tests_cdc_stream\tests_cdc_stream.exe


### PR DESCRIPTION
There were two problems:
- Writing the date on Windows used the wrong syntax. In Powershell, env variables are addressed as $env:NAME, not $NAME.
- Use different caches for opt vs fastbuild. We are currently using opt caches for fastbuilds, which results in lots of cache misses.