### PR TITLE
[cdc_stream] [cdc_rsync] Add --forward-port flag

### DIFF
--- a/all_files.vcxitems
+++ b/all_files.vcxitems
@@ -34,6 +34,8 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)cdc_stream\start_command.cc" />
     <ClCompile Include="$(MSBuildThisFileDirectory)cdc_stream\start_service_command.cc" />
     <ClCompile Include="$(MSBuildThisFileDirectory)cdc_stream\stop_service_command.cc" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)common\port_range_parser.cc" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)common\port_range_parser_test.cc" />
     <ClInclude Include="$(MSBuildThisFileDirectory)cdc_stream\stop_command.cc" />
     <ClCompile Include="$(MSBuildThisFileDirectory)cdc_stream\testing_asset_stream_server.cc" />
     <ClCompile Include="$(MSBuildThisFileDirectory)cdc_fuse_fs\asset.cc" />
@@ -144,6 +146,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)metrics\messages_test.cc" />
     <ClCompile Include="$(MSBuildThisFileDirectory)metrics\metrics.cc" />
     <ClInclude Include="$(MSBuildThisFileDirectory)cdc_stream\stop_service_command.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)common\port_range_parser.h" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)absl_helper\jedec_size_flag.h" />

--- a/cdc_rsync/BUILD
+++ b/cdc_rsync/BUILD
@@ -130,6 +130,7 @@ cc_library(
     hdrs = ["params.h"],
     deps = [
         ":cdc_rsync_client",
+        "//common:port_range_parser",
         "@com_github_zstd//:zstd",
         "@com_google_absl//absl/status",
     ],

--- a/cdc_rsync/cdc_rsync_client.h
+++ b/cdc_rsync/cdc_rsync_client.h
@@ -50,6 +50,8 @@ class CdcRsyncClient {
     std::string copy_dest;
     int compress_level = 6;
     int connection_timeout_sec = 10;
+    int forward_port_first = 44450;
+    int forward_port_last = 44459;
     std::string ssh_command;
     std::string scp_command;
     std::string sources_dir;  // Base dir for files loaded for --files-from.

--- a/cdc_rsync/params_test.cc
+++ b/cdc_rsync/params_test.cc
@@ -536,6 +536,72 @@ TEST_F(ParamsTest, IncludeExcludeMixed_ProperOrder) {
   ExpectNoError();
 }
 
+TEST_F(ParamsTest, ForwardPort_Single) {
+  const char* argv[] = {"cdc_rsync.exe", "--forward-port=65535", kSrc,
+                        kUserHostDst, NULL};
+  EXPECT_TRUE(Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
+  EXPECT_EQ(parameters_.options.forward_port_first, 65535);
+  EXPECT_EQ(parameters_.options.forward_port_last, 65535);
+  ExpectNoError();
+}
+
+TEST_F(ParamsTest, ForwardPort_Range) {
+  const char* argv[] = {"cdc_rsync.exe", "--forward-port=1-2", kSrc,
+                        kUserHostDst, NULL};
+  EXPECT_TRUE(Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
+  EXPECT_EQ(parameters_.options.forward_port_first, 1);
+  EXPECT_EQ(parameters_.options.forward_port_last, 2);
+  ExpectNoError();
+}
+
+TEST_F(ParamsTest, ForwardPort_NoValue) {
+  const char* argv[] = {"cdc_rsync.exe", "--forward-port=", kSrc, kUserHostDst,
+                        NULL};
+  EXPECT_FALSE(
+      Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
+  ExpectError(NeedsValueError("forward-port"));
+}
+
+TEST_F(ParamsTest, ForwardPort_BadValueTooSmall) {
+  const char* argv[] = {"cdc_rsync.exe", "--forward-port=0", kSrc, kUserHostDst,
+                        NULL};
+  EXPECT_FALSE(
+      Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
+  ExpectError("Invalid port '0'");
+}
+
+TEST_F(ParamsTest, ForwardPort_BadValueNotInteger) {
+  const char* argv[] = {"cdc_rsync.exe", "--forward-port=port", kSrc,
+                        kUserHostDst, NULL};
+  EXPECT_FALSE(
+      Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
+  ExpectError("Invalid port 'port'");
+}
+
+TEST_F(ParamsTest, ForwardPort_BadRangeTooBig) {
+  const char* argv[] = {"cdc_rsync.exe", "--forward-port=50000-65536", kSrc,
+                        kUserHostDst, NULL};
+  EXPECT_FALSE(
+      Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
+  ExpectError("Invalid port range '50000-65536'");
+}
+
+TEST_F(ParamsTest, ForwardPort_BadRangeFirstGtLast) {
+  const char* argv[] = {"cdc_rsync.exe", "--forward-port=50001-50000", kSrc,
+                        kUserHostDst, NULL};
+  EXPECT_FALSE(
+      Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
+  ExpectError("Invalid port range '50001-50000'");
+}
+
+TEST_F(ParamsTest, ForwardPort_BadRangeTwoMinus) {
+  const char* argv[] = {"cdc_rsync.exe", "--forward-port=1-2-3", kSrc,
+                        kUserHostDst, NULL};
+  EXPECT_FALSE(
+      Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
+  ExpectError("Invalid port range '1-2-3'");
+}
+
 }  // namespace
 }  // namespace params
 }  // namespace cdc_ft

--- a/cdc_rsync/params_test.cc
+++ b/cdc_rsync/params_test.cc
@@ -546,8 +546,8 @@ TEST_F(ParamsTest, ForwardPort_Single) {
 }
 
 TEST_F(ParamsTest, ForwardPort_Range) {
-  const char* argv[] = {"cdc_rsync.exe", "--forward-port=1-2", kSrc,
-                        kUserHostDst, NULL};
+  const char* argv[] = {
+      "cdc_rsync.exe", "--forward-port", "1-2", kSrc, kUserHostDst, NULL};
   EXPECT_TRUE(Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
   EXPECT_EQ(parameters_.options.forward_port_first, 1);
   EXPECT_EQ(parameters_.options.forward_port_last, 2);
@@ -567,39 +567,7 @@ TEST_F(ParamsTest, ForwardPort_BadValueTooSmall) {
                         NULL};
   EXPECT_FALSE(
       Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
-  ExpectError("Invalid port '0'");
-}
-
-TEST_F(ParamsTest, ForwardPort_BadValueNotInteger) {
-  const char* argv[] = {"cdc_rsync.exe", "--forward-port=port", kSrc,
-                        kUserHostDst, NULL};
-  EXPECT_FALSE(
-      Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
-  ExpectError("Invalid port 'port'");
-}
-
-TEST_F(ParamsTest, ForwardPort_BadRangeTooBig) {
-  const char* argv[] = {"cdc_rsync.exe", "--forward-port=50000-65536", kSrc,
-                        kUserHostDst, NULL};
-  EXPECT_FALSE(
-      Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
-  ExpectError("Invalid port range '50000-65536'");
-}
-
-TEST_F(ParamsTest, ForwardPort_BadRangeFirstGtLast) {
-  const char* argv[] = {"cdc_rsync.exe", "--forward-port=50001-50000", kSrc,
-                        kUserHostDst, NULL};
-  EXPECT_FALSE(
-      Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
-  ExpectError("Invalid port range '50001-50000'");
-}
-
-TEST_F(ParamsTest, ForwardPort_BadRangeTwoMinus) {
-  const char* argv[] = {"cdc_rsync.exe", "--forward-port=1-2-3", kSrc,
-                        kUserHostDst, NULL};
-  EXPECT_FALSE(
-      Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
-  ExpectError("Invalid port range '1-2-3'");
+  ExpectError("Failed to parse");
 }
 
 }  // namespace

--- a/cdc_stream/BUILD
+++ b/cdc_stream/BUILD
@@ -24,6 +24,7 @@ cc_library(
     hdrs = ["base_command.h"],
     deps = [
         "//absl_helper:jedec_size_flag",
+        "//common:port_range_parser",
         "@com_github_lyra//:lyra",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings:str_format",

--- a/cdc_stream/asset_stream_config.h
+++ b/cdc_stream/asset_stream_config.h
@@ -48,18 +48,21 @@ class AssetStreamConfig {
   // Loads a configuration from the JSON file at |path| and overrides any config
   // values that are set in this file. Sample json file:
   // {
+  //   "service-port":44432
+  //   "forward-port-first":"44433"
+  //   "forward-port-last":"44442"
   //   "verbosity":3,
   //   "debug":0,
   //   "singlethreaded":0,
   //   "stats":0,
   //   "quiet":0,
   //   "check":0,
-  //   "log_to_stdout":0,
-  //   "cache_capacity":"150G",
-  //   "cleanup_timeout":300,
-  //   "access_idle_timeout":5,
-  //   "manifest_updater_threads":4,
-  //   "file_change_wait_duration_ms":500
+  //   "log-to-stdout":0,
+  //   "cache-capacity":"150G",
+  //   "cleanup-timeout":300,
+  //   "access-idle-timeout":5,
+  //   "manifest-updater-threads":4,
+  //   "file-change-wait-duration-ms":500
   // }
   // Returns NotFoundError if the file does not exist.
   // Returns InvalidArgumentError if the file is not valid JSON.

--- a/cdc_stream/base_command.h
+++ b/cdc_stream/base_command.h
@@ -48,6 +48,13 @@ class BaseCommand {
   std::function<void(const std::string&)> JedecParser(const char* flag_name,
                                                       uint64_t* bytes);
 
+  // Parser for single ports "123" or port ranges "123-234". Usage:
+  //   lyra::opt(PortRangeParser("port-flag", &first, &last), "port"))
+  // Automatically reports a parse failure on error.
+  std::function<void(const std::string&)> PortRangeParser(const char* flag_name,
+                                                          uint16_t* first,
+                                                          uint16_t* last);
+
   // Validator that should be used for all positional arguments. Lyra interprets
   // -u, --unknown_flag as positional argument. This validator makes sure that
   // a positional argument starting with - is reported as an error. Otherwise,
@@ -82,9 +89,9 @@ class BaseCommand {
   // Extraneous positional args. Gets reported as error if present.
   std::string extra_positional_arg_;
 
-  // Errors from parsing JEDEC sizes.
+  // Errors from custom flag parsers, e.g. JEDEC sizes or port ranges.
   // Works around Lyra not accepting errors from parsers.
-  std::string jedec_parse_error_;
+  std::string parse_error_;
 };
 
 }  // namespace cdc_ft

--- a/cdc_stream/cdc_stream.vcxproj
+++ b/cdc_stream/cdc_stream.vcxproj
@@ -47,7 +47,7 @@
     <AdditionalOptions>/std:c++17</AdditionalOptions>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)bazel-out\x64_windows-opt\bin\asset_stcdc_streamream_manager\</OutDir>
+    <OutDir>$(SolutionDir)bazel-out\x64_windows-opt\bin\cdc_stream\</OutDir>
     <NMakePreprocessorDefinitions>UNICODE</NMakePreprocessorDefinitions>
     <AdditionalOptions>/std:c++17</AdditionalOptions>
   </PropertyGroup>

--- a/cdc_stream/multi_session.h
+++ b/cdc_stream/multi_session.h
@@ -134,6 +134,11 @@ class MultiSessionRunner {
 // to an arbitrary number of gamelets.
 class MultiSession {
  public:
+  // Ports used by the asset streaming service for local port forwarding on
+  // workstation and gamelet.
+  static constexpr int kDefaultForwardPortFirst = 44433;
+  static constexpr int kDefaultForwardPortLast = 44442;
+
   // Maximum length of cache path. We must be able to write content hashes into
   // this path:
   // <cache path>\01234567890123456789<null terminator> = 260 characters.

--- a/cdc_stream/session_config.h
+++ b/cdc_stream/session_config.h
@@ -56,6 +56,10 @@ struct SessionConfig {
 
   // Time to wait until running a manifest update after detecting a file change.
   uint32_t file_change_wait_duration_ms = 0;
+
+  // Ports used for local port forwarding.
+  uint16_t forward_port_first = 0;
+  uint16_t forward_port_last = 0;
 };
 
 }  // namespace cdc_ft

--- a/cdc_stream/start_command.cc
+++ b/cdc_stream/start_command.cc
@@ -22,7 +22,6 @@
 #include "common/log.h"
 #include "common/path.h"
 #include "common/process.h"
-#include "common/remote_util.h"
 #include "common/status_macros.h"
 #include "common/stopwatch.h"
 #include "common/util.h"

--- a/common/BUILD
+++ b/common/BUILD
@@ -255,6 +255,25 @@ cc_test(
 )
 
 cc_library(
+    name = "port_range_parser",
+    srcs = ["port_range_parser.cc"],
+    hdrs = ["port_range_parser.h"],
+    deps = [
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "port_range_parser_test",
+    srcs = ["port_range_parser_test.cc"],
+    deps = [
+        ":port_range_parser",
+        ":test_main",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
     name = "process",
     srcs = ["process_win.cc"],
     hdrs = ["process.h"],

--- a/common/port_manager.h
+++ b/common/port_manager.h
@@ -51,14 +51,11 @@ class PortManager {
   // Reserves a port in the range passed to the constructor. The port is
   // released automatically upon destruction if ReleasePort() is not called
   // explicitly.
-  // |check_remote| determines whether the remote port should be checked as
-  // well. If false, the check is skipped and a port might be returned that is
-  // still in use remotely.
   // |remote_timeout_sec| is the timeout for finding available ports on the
-  // remote instance. Not used if |check_remote| is false.
+  // remote instance.
   // Returns a DeadlineExceeded error if the timeout is exceeded.
   // Returns a ResourceExhausted error if no ports are available.
-  absl::StatusOr<int> ReservePort(bool check_remote, int remote_timeout_sec);
+  absl::StatusOr<int> ReservePort(int remote_timeout_sec);
 
   // Releases a reserved port.
   absl::Status ReleasePort(int port);

--- a/common/port_range_parser.cc
+++ b/common/port_range_parser.cc
@@ -1,0 +1,40 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/port_range_parser.h"
+
+#include <cassert>
+
+#include "absl/strings/str_split.h"
+
+namespace cdc_ft {
+namespace port_range {
+
+bool Parse(const char* value, uint16_t* first, uint16_t* last) {
+  assert(value);
+  *first = 0;
+  *last = 0;
+  std::vector<std::string> parts = absl::StrSplit(value, '-');
+  if (parts.empty() || parts.size() > 2) return false;
+  const int ifirst = atoi(parts[0].c_str());
+  const int ilast = parts.size() > 1 ? atoi(parts[1].c_str()) : ifirst;
+  if (ifirst <= 0 || ifirst > UINT16_MAX) return false;
+  if (ilast <= 0 || ilast > UINT16_MAX || ifirst > ilast) return false;
+  *first = static_cast<uint16_t>(ifirst);
+  *last = static_cast<uint16_t>(ilast);
+  return true;
+}
+
+}  // namespace port_range
+}  // namespace cdc_ft

--- a/common/port_range_parser.h
+++ b/common/port_range_parser.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef COMMON_PORT_RANGE_PARSER_H_
+#define COMMON_PORT_RANGE_PARSER_H_
+
+#include <cstdint>
+
+namespace cdc_ft {
+namespace port_range {
+
+// Parses |value| into a port range |first|-|last|.
+// If |value| is a single number a, assigns |first|=|last|=a.
+// If |value| is a range a-b, assigns |first|=a, |last|=b.
+bool Parse(const char* value, uint16_t* first, uint16_t* last);
+
+}  // namespace port_range
+}  // namespace cdc_ft
+
+#endif  // COMMON_PORT_RANGE_PARSER_H_

--- a/common/port_range_parser_test.cc
+++ b/common/port_range_parser_test.cc
@@ -1,0 +1,69 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/port_range_parser.h"
+
+#include "gtest/gtest.h"
+
+namespace cdc_ft {
+namespace {
+
+TEST(PortRangeParserTest, SingleSuccess) {
+  uint16_t first, last;
+  EXPECT_TRUE(port_range::Parse("65535", &first, &last));
+  EXPECT_EQ(first, 65535);
+  EXPECT_EQ(last, 65535);
+}
+
+TEST(PortRangeParserTest, RangeSuccess) {
+  uint16_t first, last;
+  EXPECT_TRUE(port_range::Parse("1-2", &first, &last));
+  EXPECT_EQ(first, 1);
+  EXPECT_EQ(last, 2);
+}
+
+TEST(ParamsTest, NoValueFail) {
+  uint16_t first = 1, last = 1;
+  EXPECT_FALSE(port_range::Parse("", &first, &last));
+  EXPECT_EQ(first, 0);
+  EXPECT_EQ(last, 0);
+}
+
+TEST(ParamsTest, BadValueTooSmallFail) {
+  uint16_t first, last;
+  EXPECT_FALSE(port_range::Parse("0", &first, &last));
+}
+
+TEST(ParamsTest, BadValueNotIntegerFail) {
+  uint16_t first, last;
+  EXPECT_FALSE(port_range::Parse("port", &first, &last));
+}
+
+TEST(ParamsTest, ForwardPort_BadRangeTooBig) {
+  uint16_t first, last;
+  EXPECT_FALSE(port_range::Parse("50000-65536", &first, &last));
+}
+
+TEST(ParamsTest, ForwardPort_BadRangeFirstGtLast) {
+  uint16_t first, last;
+  EXPECT_FALSE(port_range::Parse("50001-50000", &first, &last));
+}
+
+TEST(ParamsTest, ForwardPort_BadRangeTwoMinus) {
+  uint16_t first, last;
+  EXPECT_FALSE(port_range::Parse("1-2-3", &first, &last));
+}
+
+}  // namespace
+}  // namespace cdc_ft

--- a/tests_common/BUILD
+++ b/tests_common/BUILD
@@ -30,6 +30,7 @@ cc_binary(
         "//common:path_filter",
         "//common:platform",
         "//common:port_manager",
+        "//common:port_range_parser",
         "//common:process",
         "//common:remote_util",
         "//common:sdk_util",


### PR DESCRIPTION
[cdc_stream] [cdc_rsync] Add --forward-port flag

Adds a flag to set the SSH forwarding port or port range used for
'cdc_stream start-service' and 'cdc_rsync'.

If a single number is passed, e.g. --forward-port 12345, then this
port is used without checking availability of local and remote ports.
If the port is taken, this results in an error when trying to connect.
Note that this restricts the number of connections that stream can
make to one.

If a range is passed, e.g. --forward-port 45000-46000, the tools
search for available ports locally and remotely in that range. This is
more robust, but a bit slower due to the extra overhead.

Optimizes port_manager_win as it was very slow for a large port range.
It's still not optimal, but the time needed to scan 30k ports is
<< 1 seconds now.
