### PR TITLE
[common] Fix FileWatcherTest once and for all

### DIFF
--- a/common/file_watcher_win.cc
+++ b/common/file_watcher_win.cc
@@ -164,6 +164,11 @@ class AsyncFileWatcher {
            state_ != FileWatcherState::kShuttingDown;
   }
 
+  bool IsRunning() const ABSL_LOCKS_EXCLUDED(state_mutex_) {
+    absl::MutexLock mutex(&state_mutex_);
+    return state_ == FileWatcherState::kRunning;
+  }
+
   bool IsShuttingDown() const ABSL_LOCKS_EXCLUDED(state_mutex_) {
     absl::MutexLock mutex(&state_mutex_);
     return state_ == FileWatcherState::kShuttingDown;
@@ -612,6 +617,10 @@ absl::Status FileWatcherWin::StopWatching() {
 
 bool FileWatcherWin::IsWatching() const {
   return async_watcher_ ? async_watcher_->IsWatching() : false;
+}
+
+bool FileWatcherWin::IsRunning() const {
+  return async_watcher_ ? async_watcher_->IsRunning() : false;
 }
 
 absl::Status FileWatcherWin::GetStatus() const {

--- a/common/file_watcher_win.h
+++ b/common/file_watcher_win.h
@@ -77,8 +77,13 @@ class FileWatcherWin {
   // Stops watching directory changes.
   absl::Status StopWatching() ABSL_LOCKS_EXCLUDED(modified_files_mutex_);
 
-  // Indicates whether a directory is currently watched.
+  // Indicates whether StartWatching() was called, but StopWatching() was not
+  // called yet.
   bool IsWatching() const;
+
+  // Indicates whether a directory is actively watched for changes. In contrast
+  // to Iswatching(), returns false while the directory does not exist.
+  bool IsRunning() const;
 
   // Returns the watching status.
   absl::Status GetStatus() const;

--- a/common/file_watcher_win.h
+++ b/common/file_watcher_win.h
@@ -79,11 +79,11 @@ class FileWatcherWin {
 
   // Indicates whether StartWatching() was called, but StopWatching() was not
   // called yet.
-  bool IsWatching() const;
+  bool IsStarted() const;
 
   // Indicates whether a directory is actively watched for changes. In contrast
-  // to Iswatching(), returns false while the directory does not exist.
-  bool IsRunning() const;
+  // to IsStarted(), returns false while the directory does not exist.
+  bool IsWatching() const;
 
   // Returns the watching status.
   absl::Status GetStatus() const;

--- a/common/file_watcher_win_test.cc
+++ b/common/file_watcher_win_test.cc
@@ -138,7 +138,7 @@ class FileWatcherParameterizedTest : public ::testing::TestWithParam<bool> {
   // Polls for a second until the watcher is running again.
   bool WaitForRunning() const {
     for (int n = 0; n < 1000; ++n) {
-      if (watcher_.IsRunning()) return true;
+      if (watcher_.IsWatching()) return true;
       Util::Sleep(1);
     }
     return false;
@@ -210,7 +210,7 @@ TEST_P(FileWatcherParameterizedTest, DirDoesNotExist) {
   if (legacyReadDirectoryChanges_)
     watcher_.EnforceLegacyReadDirectoryChangesForTesting();
   EXPECT_NOT_OK(watcher.StartWatching([this]() { OnFilesChanged(); }));
-  EXPECT_FALSE(watcher.IsWatching());
+  EXPECT_FALSE(watcher.IsStarted());
   absl::Status status = watcher.GetStatus();
   EXPECT_NOT_OK(status);
   EXPECT_TRUE(absl::IsFailedPrecondition(status));

--- a/common/file_watcher_win_test.cc
+++ b/common/file_watcher_win_test.cc
@@ -135,10 +135,10 @@ class FileWatcherParameterizedTest : public ::testing::TestWithParam<bool> {
     return changed;
   }
 
-  // Polls for a second until the watcher is watching again.
-  bool WaitForWatching() const {
+  // Polls for a second until the watcher is running again.
+  bool WaitForRunning() const {
     for (int n = 0; n < 1000; ++n) {
-      if (watcher_.IsWatching()) return true;
+      if (watcher_.IsRunning()) return true;
       Util::Sleep(1);
     }
     return false;
@@ -549,8 +549,8 @@ TEST_P(FileWatcherParameterizedTest, RecreateWatchedDir) {
   EXPECT_TRUE(watcher_.GetModifiedFiles().empty());
   EXPECT_OK(watcher_.GetStatus());
 
-  // Wait until the watcher is watching again, or else we might miss the file.
-  EXPECT_TRUE(WaitForWatching());
+  // Wait until the watcher is running again, or else we might miss the file.
+  EXPECT_TRUE(WaitForRunning());
 
   // Creation of a new file should be detected.
   EXPECT_OK(path::WriteFile(first_file_path_, kFirstData, kFirstDataSize));
@@ -584,8 +584,8 @@ TEST_P(FileWatcherParameterizedTest, RecreateUpperDir) {
   EXPECT_TRUE(watcher_.GetModifiedFiles().empty());
   EXPECT_OK(watcher_.GetStatus());
 
-  // Wait until the watcher is watching again, or else we might miss the file.
-  EXPECT_TRUE(WaitForWatching());
+  // Wait until the watcher is running again, or else we might miss the file.
+  EXPECT_TRUE(WaitForRunning());
 
   // Creation of a new file should be detected.
   EXPECT_OK(path::WriteFile(first_file_path_, kFirstData, kFirstDataSize));


### PR DESCRIPTION
But...

ONCE AND FOR ALL!

A recent change introduced WaitForWatching(), which was supposed to block until the file watcher is actively monitoring the directory. However this always returned immediately since the watcher is in kFailed state if the directory was deleted, which counts as watching (IsWatching returns true for both kRunning and kFailed states).

This CL adds an IsRunning() helper function that returns true only for the kRunning state, which means that the directory is actively being watched.