### PR TITLE
[cdc_rsync] Fix issue in UnzstdStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CDC File Transfer
 
-Born from the ashes of Stadia, this repository contains tools for synching and
+Born from the ashes of Stadia, this repository contains tools for syncing and
 streaming files from Windows to Linux. They are based on Content Defined
 Chunking (CDC), in particular
 [FastCDC](https://www.usenix.org/conference/atc16/technical-sessions/presentation/xia),

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ another development branch, where the delta was much higher. Overall,
 We also ran the experiment with the native Linux `rsync`, i.e syncing Linux to
 Linux, to rule out issues with Cygwin. Linux `rsync` performed on average 35%
 worse than Cygwin `rsync`, which can be attributed to CPU differences. We did
-not include it in the figure because to this, but you can find it
+not include it in the figure because of this, but you can find it
 [here](docs/cdc_rsync_vs_cygwin_rsync_vs_linux_rsync.png).
 
 ### How does it work and why is it faster?

--- a/cdc_rsync/base/fake_socket.cc
+++ b/cdc_rsync/base/fake_socket.cc
@@ -39,7 +39,8 @@ absl::Status FakeSocket::Receive(void* buffer, size_t size,
   *bytes_received = 0;
   std::unique_lock<std::mutex> lock(data_mutex_);
   data_cv_.wait(lock, [this, size, allow_partial_read]() {
-    return allow_partial_read || data_.size() >= size || shutdown_;
+    size_t min_size = allow_partial_read ? 1 : size;
+    return data_.size() >= min_size || shutdown_;
   });
   if (shutdown_) {
     return absl::UnavailableError("Pipe is shut down");

--- a/cdc_rsync/cdc_rsync_client.cc
+++ b/cdc_rsync/cdc_rsync_client.cc
@@ -779,9 +779,9 @@ absl::Status CdcRsyncClient::StopCompressionStream() {
   message_pump_.FlushOutgoingQueue();
   message_pump_.RedirectOutput(nullptr);
 
-  // Flush compression stream and reset.
-  RETURN_IF_ERROR(compression_stream_->Flush(),
-                  "Failed to flush compression stream");
+  // Finish compression stream and reset.
+  RETURN_IF_ERROR(compression_stream_->Finish(),
+                  "Failed to finish compression stream");
   compression_stream_.reset();
 
   // Wait for the server ack. This must be done before sending more data.

--- a/cdc_rsync/zstd_stream.cc
+++ b/cdc_rsync/zstd_stream.cc
@@ -27,28 +27,30 @@ namespace {
 // trigger a flush. This happens when files with no changes are diff'ed (this
 // produces very low volume data). Flushing prevents that the server gets stale
 // and becomes overwhelmed later.
-constexpr absl::Duration kMinCompressPeriod = absl::Milliseconds(500);
+constexpr absl::Duration kDefaultMinCompressPeriod = absl::Milliseconds(500);
 
 }  // namespace
 
 ZstdStream::ZstdStream(Socket* socket, int level, uint32_t num_threads)
-    : socket_(socket), cctx_(nullptr) {
+    : socket_(socket),
+      cctx_(nullptr),
+      min_compress_period_(kDefaultMinCompressPeriod) {
   status_ = WrapStatus(Initialize(level, num_threads),
                        "Failed to initialize stream compressor");
 }
 
 ZstdStream::~ZstdStream() {
-  if (cctx_) {
-    ZSTD_freeCCtx(cctx_);
-    cctx_ = nullptr;
-  }
-
   {
     absl::MutexLock lock(&mutex_);
     shutdown_ = true;
   }
   if (compressor_thread_.joinable()) {
     compressor_thread_.join();
+  }
+
+  if (cctx_) {
+    ZSTD_freeCCtx(cctx_);
+    cctx_ = nullptr;
   }
 }
 
@@ -134,7 +136,7 @@ void ZstdStream::ThreadCompressorMain() {
              in_buffer_.size() == in_buffer_.capacity();
     };
     bool flush =
-        !mutex_.AwaitWithTimeout(absl::Condition(&cond), kMinCompressPeriod);
+        !mutex_.AwaitWithTimeout(absl::Condition(&cond), min_compress_period_);
     if (shutdown_) {
       return;
     }

--- a/cdc_rsync/zstd_stream.h
+++ b/cdc_rsync/zstd_stream.h
@@ -39,6 +39,11 @@ class ZstdStream {
   // Flushes all remaining data and sends the compressed data to the socket.
   absl::Status Flush() ABSL_LOCKS_EXCLUDED(mutex_);
 
+  // Flush internal buffers if no new data is written for longer than this time.
+  // This makes sure that no data is stuck in the pipeline if no new input is
+  // available. Default is 500 ms.
+  void SetMinCompressPeriod(absl::Duration dur) { min_compress_period_ = dur; }
+
  private:
   // Initializes the compressor and related data.
   absl::Status Initialize(int level, uint32_t num_threads)
@@ -58,6 +63,8 @@ class ZstdStream {
   bool last_chunk_sent_ ABSL_GUARDED_BY(mutex_) = false;
   absl::Status status_ ABSL_GUARDED_BY(mutex_);
   std::thread compressor_thread_;
+
+  absl::Duration min_compress_period_;
 };
 
 }  // namespace cdc_ft

--- a/cdc_rsync/zstd_stream.h
+++ b/cdc_rsync/zstd_stream.h
@@ -36,13 +36,13 @@ class ZstdStream {
   // Sends the given |data| to the compressor.
   absl::Status Write(const void* data, size_t size) ABSL_LOCKS_EXCLUDED(mutex_);
 
-  // Flushes all remaining data and sends the compressed data to the socket.
-  absl::Status Flush() ABSL_LOCKS_EXCLUDED(mutex_);
+  // Finishes the stream and flushes all remaining data.
+  absl::Status Finish() ABSL_LOCKS_EXCLUDED(mutex_);
 
-  // Flush internal buffers if no new data is written for longer than this time.
-  // This makes sure that no data is stuck in the pipeline if no new input is
-  // available. Default is 500 ms.
-  void SetMinCompressPeriod(absl::Duration dur) { min_compress_period_ = dur; }
+  // Flushes internal buffers if no new data is written for longer than this
+  // time. This makes sure that no data is stuck in the pipeline if no new input
+  // is available. Default is 500 ms.
+  void AutoFlushAfter(absl::Duration dur) { auto_flush_period_ = dur; }
 
  private:
   // Initializes the compressor and related data.
@@ -64,7 +64,7 @@ class ZstdStream {
   absl::Status status_ ABSL_GUARDED_BY(mutex_);
   std::thread compressor_thread_;
 
-  absl::Duration min_compress_period_;
+  absl::Duration auto_flush_period_;
 };
 
 }  // namespace cdc_ft

--- a/common/file_watcher_win.cc
+++ b/common/file_watcher_win.cc
@@ -65,7 +65,13 @@ int64_t ToUnixTime(LARGE_INTEGER windows_time) {
 // Background thread to read directory changes.
 class AsyncFileWatcher {
  public:
-  enum class FileWatcherState { kDefault, kFailed, kRunning, kShuttingDown };
+  enum class FileWatcherState {
+    kDefault,      // Not started.
+    kFailed,       // Some error during watching, e.g. directory got deleted.
+                   // Will attempt to recover automatically.
+    kWatching,     // Actively watching directory.
+    kShuttingDown  // Shutdown() was called, winding watcher down.
+  };
 
   using FileAction = FileWatcherWin::FileAction;
   using FileInfo = FileWatcherWin::FileInfo;
@@ -158,10 +164,15 @@ class AsyncFileWatcher {
     return dir_recreate_count_;
   }
 
-  bool IsWatching() const ABSL_LOCKS_EXCLUDED(state_mutex_) {
+  bool IsStarted() const ABSL_LOCKS_EXCLUDED(state_mutex_) {
     absl::MutexLock mutex(&state_mutex_);
     return state_ != FileWatcherState::kDefault &&
            state_ != FileWatcherState::kShuttingDown;
+  }
+
+  bool IsWatching() const ABSL_LOCKS_EXCLUDED(state_mutex_) {
+    absl::MutexLock mutex(&state_mutex_);
+    return state_ == FileWatcherState::kWatching;
   }
 
   bool IsShuttingDown() const ABSL_LOCKS_EXCLUDED(state_mutex_) {
@@ -322,7 +333,7 @@ class AsyncFileWatcher {
       return;
     }
 
-    MaybeSetState(FileWatcherState::kRunning);
+    MaybeSetState(FileWatcherState::kWatching);
     // Initialize handles to watch: changes in |dir_path_| and shutdown
     // events.
     HANDLE watch_handles[] = {overlapped.hEvent, shutdown_event_.Get()};
@@ -585,7 +596,7 @@ absl::Status FileWatcherWin::StartWatching(FilesChangedCb files_changed_cb,
   async_watcher_ = std::make_unique<AsyncFileWatcher>(
       dir_path_, std::move(files_changed_cb), std::move(dir_recreated_cb),
       timeout_ms, enforceLegacyReadDirectoryChangesForTesting_);
-  while (GetStatus().ok() && !IsWatching()) {
+  while (GetStatus().ok() && !IsStarted()) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   return GetStatus();
@@ -610,6 +621,10 @@ absl::Status FileWatcherWin::StopWatching() {
   return async_status;
 }
 
+bool FileWatcherWin::IsStarted() const {
+  return async_watcher_ ? async_watcher_->IsStarted() : false;
+}
+
 bool FileWatcherWin::IsWatching() const {
   return async_watcher_ ? async_watcher_->IsWatching() : false;
 }
@@ -627,7 +642,7 @@ uint32_t FileWatcherWin::GetDirRecreateEventCountForTesting() const {
 }
 
 void FileWatcherWin::EnforceLegacyReadDirectoryChangesForTesting() {
-  assert(!IsWatching());
+  assert(!IsStarted());
   enforceLegacyReadDirectoryChangesForTesting_ = true;
 }
 

--- a/common/file_watcher_win.h
+++ b/common/file_watcher_win.h
@@ -77,7 +77,12 @@ class FileWatcherWin {
   // Stops watching directory changes.
   absl::Status StopWatching() ABSL_LOCKS_EXCLUDED(modified_files_mutex_);
 
-  // Indicates whether a directory is currently watched.
+  // Indicates whether StartWatching() was called, but StopWatching() was not
+  // called yet.
+  bool IsStarted() const;
+
+  // Indicates whether a directory is actively watched for changes. In contrast
+  // to IsStarted(), returns false while the directory does not exist.
   bool IsWatching() const;
 
   // Returns the watching status.

--- a/common/file_watcher_win_test.cc
+++ b/common/file_watcher_win_test.cc
@@ -135,8 +135,8 @@ class FileWatcherParameterizedTest : public ::testing::TestWithParam<bool> {
     return changed;
   }
 
-  // Polls for a second until the watcher is watching again.
-  bool WaitForWatching() const {
+  // Polls for a second until the watcher is running again.
+  bool WaitForRunning() const {
     for (int n = 0; n < 1000; ++n) {
       if (watcher_.IsWatching()) return true;
       Util::Sleep(1);
@@ -210,7 +210,7 @@ TEST_P(FileWatcherParameterizedTest, DirDoesNotExist) {
   if (legacyReadDirectoryChanges_)
     watcher_.EnforceLegacyReadDirectoryChangesForTesting();
   EXPECT_NOT_OK(watcher.StartWatching([this]() { OnFilesChanged(); }));
-  EXPECT_FALSE(watcher.IsWatching());
+  EXPECT_FALSE(watcher.IsStarted());
   absl::Status status = watcher.GetStatus();
   EXPECT_NOT_OK(status);
   EXPECT_TRUE(absl::IsFailedPrecondition(status));
@@ -549,8 +549,8 @@ TEST_P(FileWatcherParameterizedTest, RecreateWatchedDir) {
   EXPECT_TRUE(watcher_.GetModifiedFiles().empty());
   EXPECT_OK(watcher_.GetStatus());
 
-  // Wait until the watcher is watching again, or else we might miss the file.
-  EXPECT_TRUE(WaitForWatching());
+  // Wait until the watcher is running again, or else we might miss the file.
+  EXPECT_TRUE(WaitForRunning());
 
   // Creation of a new file should be detected.
   EXPECT_OK(path::WriteFile(first_file_path_, kFirstData, kFirstDataSize));
@@ -584,8 +584,8 @@ TEST_P(FileWatcherParameterizedTest, RecreateUpperDir) {
   EXPECT_TRUE(watcher_.GetModifiedFiles().empty());
   EXPECT_OK(watcher_.GetStatus());
 
-  // Wait until the watcher is watching again, or else we might miss the file.
-  EXPECT_TRUE(WaitForWatching());
+  // Wait until the watcher is running again, or else we might miss the file.
+  EXPECT_TRUE(WaitForRunning());
 
   // Creation of a new file should be detected.
   EXPECT_OK(path::WriteFile(first_file_path_, kFirstData, kFirstDataSize));


### PR DESCRIPTION
Fixes an issue in UnzstdStream where the Read() method always tries to read new input data if no input data is available, instead of first trying to uncompress. Since zstd maintains internal buffers, uncompression might succeed even without reading more input, so this is faster. This bug can lead to pipeline stalls in cdc_rsync.