### PR TITLE
[cdc_rsync] [cdc_stream] Switch from scp to sftp

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ To build the tools from source, the following steps have to be executed on
   ```
 
 Finally, install an SSH client on the Windows device if not present.
-The file transfer tools require `ssh.exe` and `scp.exe`.
+The file transfer tools require `ssh.exe` and `sftp.exe`.
 
 ## Building
 
@@ -227,24 +227,24 @@ The two tools can be built and used independently.
 
 ## Usage
 
-The tools require a setup where you can use SSH and SCP from the Windows machine
-to the Linux device without entering a password, e.g. by using key-based
+The tools require a setup where you can use SSH and SFTP from the Windows
+machine to the Linux device without entering a password, e.g. by using key-based
 authentication.
 
-### Configuring SSH and SCP
+### Configuring SSH and SFTP
 
-By default, the tools search `ssh.exe` and `scp.exe` from the path environment
+By default, the tools search `ssh.exe` and `sftp.exe` from the path environment
 variable. If you can run the following commands in a Windows cmd without
 entering your password, you are all set:
 ```
 ssh user@linux.device.com
-scp somefile.txt user@linux.device.com:
+sftp user@linux.device.com
 ```
 Here, `user` is the Linux user and `linux.device.com` is the Linux host to
 SSH into or copy the file to.
 
 If additional arguments are required, it is recommended to provide an SSH config
-file. By default, both `ssh.exe` and `scp.exe` use the file at
+file. By default, both `ssh.exe` and `sftp.exe` use the file at
 `%USERPROFILE%\.ssh\config` on Windows, if it exists. A possible config file
 that sets a username, a port, an identity file and a known host file could look
 as follows:
@@ -256,21 +256,21 @@ Host linux_device
 	IdentityFile C:\path\to\id_rsa
 	UserKnownHostsFile C:\path\to\known_hosts
 ```
-If `ssh.exe` or `scp.exe` cannot be found, you can specify the full paths via
-the command line arguments `--ssh-command` and `--scp-command` for `cdc_rsync`
+If `ssh.exe` or `sftp.exe` cannot be found, you can specify the full paths via
+the command line arguments `--ssh-command` and `--sftp-command` for `cdc_rsync`
 and `cdc_stream start` (see below), or set the environment variables
-`CDC_SSH_COMMAND` and `CDC_SCP_COMMAND`, e.g.
+`CDC_SSH_COMMAND` and `CDC_SFTP_COMMAND`, e.g.
 ```
 set CDC_SSH_COMMAND="C:\path with space\to\ssh.exe"
-set CDC_SCP_COMMAND="C:\path with space\to\scp.exe"
+set CDC_SFTP_COMMAND="C:\path with space\to\sftp.exe"
 ```
 Note that you can also specify SSH configuration via the environment variables
 instead of using a config file:
 ```
 set CDC_SSH_COMMAND=C:\path\to\ssh.exe -p 12345 -i C:\path\to\id_rsa -oUserKnownHostsFile=C:\path\to\known_hosts
-set CDC_SCP_COMMAND=C:\path\to\scp.exe -P 12345 -i C:\path\to\id_rsa -oUserKnownHostsFile=C:\path\to\known_hosts
+set CDC_SFTP_COMMAND=C:\path\to\sftp.exe -P 12345 -i C:\path\to\id_rsa -oUserKnownHostsFile=C:\path\to\known_hosts
 ```
-Note the small `-p` for `ssh.exe` and the capital `-P` for `scp.exe`.
+Note the small `-p` for `ssh.exe` and the capital `-P` for `sftp.exe`.
 
 #### Google Specific
 
@@ -278,7 +278,7 @@ For Google internal usage, set the following environment variables to enable SSH
 authentication using a Google security key:
 ```
 set CDC_SSH_COMMAND=C:\gnubby\bin\ssh.exe
-set CDC_SCP_COMMAND=C:\gnubby\bin\scp.exe
+set CDC_SFTP_COMMAND=C:\gnubby\bin\sftp.exe
 ```
 Note that you will have to touch the security key multiple times during the
 first run. Subsequent runs only require a single touch.
@@ -352,7 +352,7 @@ instead of to the file.
 `cdc_rsync` always logs to the console. To increase log verbosity, pass `-vvv`
 for debug logs or `-vvvv` for verbose logs.
 
-For both sync and stream, the debug logs contain all SSH and SCP commands that
+For both sync and stream, the debug logs contain all SSH and SFTP commands that
 are attempted to run, which is very useful for troubleshooting. If a command
 fails unexpectedly, copy it and run it in isolation. Pass `-vv` or `-vvv` for
 additional debug output.

--- a/cdc_rsync/cdc_rsync_client.h
+++ b/cdc_rsync/cdc_rsync_client.h
@@ -54,9 +54,13 @@ class CdcRsyncClient {
     int forward_port_first = 44450;
     int forward_port_last = 44459;
     std::string ssh_command;
-    std::string scp_command;
+    std::string sftp_command;
     std::string sources_dir;  // Base dir for files loaded for --files-from.
     PathFilter filter;
+
+    // Backwards compatibility for switching from scp to sftp.
+    // Used internally, do not use.
+    std::string deprecated_scp_command;
 
     // Compression level 0 is invalid.
     static constexpr int kMinCompressLevel = -5;

--- a/cdc_rsync/server_arch_test.cc
+++ b/cdc_rsync/server_arch_test.cc
@@ -60,47 +60,29 @@ TEST(ServerArchTest, CdcServerFilename) {
 }
 
 TEST(ServerArchTest, RemoteToolsBinDir) {
-  const std::string linux_ssh_dir =
-      ServerArch(kLinux).RemoteToolsBinDir(ServerArch::UseCase::kSsh);
-  EXPECT_TRUE(absl::StrContains(linux_ssh_dir, "/"));
+  const std::string linux_dir = ServerArch(kLinux).RemoteToolsBinDir();
+  EXPECT_TRUE(absl::StrContains(linux_dir, ".cache/"));
 
-  const std::string linux_scp_dir =
-      ServerArch(kLinux).RemoteToolsBinDir(ServerArch::UseCase::kScp);
-  EXPECT_EQ(linux_ssh_dir, linux_scp_dir);
-
-  const std::string win_ssh_dir =
-      ServerArch(kWindows).RemoteToolsBinDir(ServerArch::UseCase::kSsh);
-  EXPECT_TRUE(absl::StrContains(win_ssh_dir, "\\"));
-  EXPECT_TRUE(absl::StrContains(win_ssh_dir, "$env:appdata"));
-
-  std::string win_scp_dir =
-      ServerArch(kWindows).RemoteToolsBinDir(ServerArch::UseCase::kScp);
-  EXPECT_TRUE(absl::StrContains(win_scp_dir, "\\"));
-  EXPECT_TRUE(absl::StrContains(win_scp_dir, "AppData\\Roaming"));
+  std::string win_dir = ServerArch(kWindows).RemoteToolsBinDir();
+  EXPECT_TRUE(absl::StrContains(win_dir, "AppData\\Roaming\\"));
 }
 
 TEST(ServerArchTest, GetStartServerCommand) {
   std::string cmd = ServerArch(kWindows).GetStartServerCommand(123, "foo bar");
   EXPECT_TRUE(absl::StrContains(cmd, "123"));
-  EXPECT_TRUE(absl::StrContains(cmd, "foo bar"));
-  EXPECT_TRUE(absl::StrContains(cmd, "New-Item "));
+  EXPECT_TRUE(absl::StrContains(cmd, "cdc_rsync_server.exe foo bar"));
 
   cmd = ServerArch(kLinux).GetStartServerCommand(123, "foo bar");
   EXPECT_TRUE(absl::StrContains(cmd, "123"));
-  EXPECT_TRUE(absl::StrContains(cmd, "foo bar"));
-  EXPECT_TRUE(absl::StrContains(cmd, "mkdir -p"));
+  EXPECT_TRUE(absl::StrContains(cmd, "cdc_rsync_server foo bar"));
 }
 
 TEST(ServerArchTest, GetDeployReplaceCommand) {
-  std::string cmd = ServerArch(kWindows).GetDeployReplaceCommand("aaa", "bbb");
-  EXPECT_TRUE(absl::StrContains(cmd, "aaa"));
-  EXPECT_TRUE(absl::StrContains(cmd, "bbb"));
-  EXPECT_TRUE(absl::StrContains(cmd, "Move-Item "));
+  std::string cmd = ServerArch(kWindows).GetDeploySftpCommands();
+  EXPECT_TRUE(absl::StrContains(cmd, "cdc_rsync_server.exe"));
 
-  cmd = ServerArch(kLinux).GetDeployReplaceCommand("aaa", "bbb");
-  EXPECT_TRUE(absl::StrContains(cmd, "aaa"));
-  EXPECT_TRUE(absl::StrContains(cmd, "bbb"));
-  EXPECT_TRUE(absl::StrContains(cmd, "mv "));
+  cmd = ServerArch(kLinux).GetDeploySftpCommands();
+  EXPECT_TRUE(absl::StrContains(cmd, "cdc_rsync_server"));
 }
 
 }  // namespace

--- a/cdc_stream/asset_stream_config.cc
+++ b/cdc_stream/asset_stream_config.cc
@@ -157,9 +157,9 @@ void AssetStreamConfig::RegisterCommandLineFlags(lyra::command& cmd,
                 "connection to the host. See also --dev-src-dir."));
 
   cmd.add_argument(
-      lyra::opt(dev_target_.scp_command, "cmd")
-          .name("--dev-scp-command")
-          .help("Scp command and extra flags to use for the "
+      lyra::opt(dev_target_.sftp_command, "cmd")
+          .name("--dev-sftp-command")
+          .help("Sftp command and extra flags to use for the "
                 "connection to the host. See also --dev-src-dir."));
 
   cmd.add_argument(
@@ -258,7 +258,7 @@ std::string AssetStreamConfig::ToString() {
   ss << "dev-user-host                = " << dev_target_.user_host << std::endl;
   ss << "dev-ssh-command              = " << dev_target_.ssh_command
      << std::endl;
-  ss << "dev-scp-command              = " << dev_target_.scp_command
+  ss << "dev-sftp-command             = " << dev_target_.sftp_command
      << std::endl;
   ss << "dev-mount-dir                = " << dev_target_.mount_dir << std::endl;
   return ss.str();

--- a/cdc_stream/local_assets_stream_manager_client.cc
+++ b/cdc_stream/local_assets_stream_manager_client.cc
@@ -38,13 +38,13 @@ LocalAssetsStreamManagerClient::~LocalAssetsStreamManagerClient() = default;
 absl::Status LocalAssetsStreamManagerClient::StartSession(
     const std::string& src_dir, const std::string& user_host,
     const std::string& mount_dir, const std::string& ssh_command,
-    const std::string& scp_command) {
+    const std::string& sftp_command) {
   StartSessionRequest request;
   request.set_workstation_directory(src_dir);
   request.set_user_host(user_host);
   request.set_mount_dir(mount_dir);
   request.set_ssh_command(ssh_command);
-  request.set_scp_command(scp_command);
+  request.set_sftp_command(sftp_command);
 
   grpc::ClientContext context;
   StartSessionResponse response;

--- a/cdc_stream/local_assets_stream_manager_client.h
+++ b/cdc_stream/local_assets_stream_manager_client.h
@@ -43,12 +43,12 @@ class LocalAssetsStreamManagerClient {
   // |user_host| is the Linux host, formatted as [user@:host].
   // |mount_dir| is the Linux target directory to stream to.
   // |ssh_command| is the ssh command and extra arguments to use.
-  // |scp_command| is the scp command and extra arguments to use.
+  // |sftp_command| is the sftp command and extra arguments to use.
   absl::Status StartSession(const std::string& src_dir,
                             const std::string& user_host,
                             const std::string& mount_dir,
                             const std::string& ssh_command,
-                            const std::string& scp_command);
+                            const std::string& sftp_command);
 
   // Stops the streaming session to the Linux target |user_host|:|mount_dir|.
   // |user_host| is the Linux host, formatted as [user@:host].

--- a/cdc_stream/local_assets_stream_manager_service_impl.cc
+++ b/cdc_stream/local_assets_stream_manager_service_impl.cc
@@ -208,7 +208,7 @@ LocalAssetsStreamManagerServiceImpl::GetTargetForStadia(
   SessionTarget target;
   target.mount_dir = request.mount_dir();
   target.ssh_command = request.ssh_command();
-  target.scp_command = request.scp_command();
+  target.sftp_command = request.sftp_command();
 
   // Parse instance/project/org id.
   if (!ParseInstanceName(request.gamelet_name(), instance_id, project_id,
@@ -223,7 +223,7 @@ LocalAssetsStreamManagerServiceImpl::GetTargetForStadia(
                    InitSsh(*instance_id, *project_id, *organization_id));
 
   target.user_host = "cloudcast@" + instance_ip;
-  // Note: Port must be set with ssh_command (-p) and scp_command (-P).
+  // Note: Port must be set with ssh_command (-p) and sftp_command (-P).
   return target;
 }
 
@@ -233,7 +233,7 @@ SessionTarget LocalAssetsStreamManagerServiceImpl::GetTarget(
   target.user_host = request.user_host();
   target.mount_dir = request.mount_dir();
   target.ssh_command = request.ssh_command();
-  target.scp_command = request.scp_command();
+  target.sftp_command = request.sftp_command();
 
   *instance_id = absl::StrCat(target.user_host, ":", target.mount_dir);
   return target;

--- a/cdc_stream/session.cc
+++ b/cdc_stream/session.cc
@@ -55,8 +55,8 @@ Session::Session(std::string instance_id, const SessionTarget& target,
   if (!target.ssh_command.empty()) {
     remote_util_.SetSshCommand(target.ssh_command);
   }
-  if (!target.scp_command.empty()) {
-    remote_util_.SetScpCommand(target.scp_command);
+  if (!target.sftp_command.empty()) {
+    remote_util_.SetSftpCommand(target.sftp_command);
   }
 }
 

--- a/cdc_stream/session.h
+++ b/cdc_stream/session.h
@@ -38,8 +38,8 @@ struct SessionTarget {
   std::string user_host;
   // Ssh command to use to connect to the remote target.
   std::string ssh_command;
-  // Scp command to use to copy files to the remote target.
-  std::string scp_command;
+  // Sftp command to use to copy files to the remote target.
+  std::string sftp_command;
   // Directory on the remote target where to mount the streamed directory.
   std::string mount_dir;
 };

--- a/cdc_stream/start_command.h
+++ b/cdc_stream/start_command.h
@@ -44,9 +44,11 @@ class StartCommand : public BaseCommand {
   int verbosity_ = 0;
   uint16_t service_port_ = 0;
   std::string ssh_command_;
-  std::string scp_command_;
+  std::string sftp_command_;
   std::string src_dir_;
   std::string user_host_dir_;
+
+  std::string deprecated_scp_command_;
 };
 
 }  // namespace cdc_ft

--- a/cdc_stream/start_service_command.cc
+++ b/cdc_stream/start_service_command.cc
@@ -141,7 +141,7 @@ absl::Status StartServiceCommand::RunService() {
     request.set_user_host(cfg_.dev_target().user_host);
     request.set_mount_dir(cfg_.dev_target().mount_dir);
     request.set_ssh_command(cfg_.dev_target().ssh_command);
-    request.set_scp_command(cfg_.dev_target().scp_command);
+    request.set_sftp_command(cfg_.dev_target().sftp_command);
     localassetsstreammanager::StartSessionResponse response;
     RETURN_ABSL_IF_ERROR(
         session_service.StartSession(nullptr, &request, &response));

--- a/proto/local_assets_stream_manager.proto
+++ b/proto/local_assets_stream_manager.proto
@@ -48,9 +48,9 @@ message StartSessionRequest {
   // SSH command to connect to the remote instance.
   // Optional, falls back to searching ssh.
   string ssh_command = 10;
-  // SCP command to copy files to the remote instance.
-  // Optional, falls back to searching scp.
-  string scp_command = 11;
+  // SFTP command to copy files to the remote instance.
+  // Optional, falls back to searching sftp.
+  string sftp_command = 11;
 
   reserved 1, 3, 4, 9;
 }


### PR DESCRIPTION
Use sftp for deploying remote components instead of scp. sftp has the advantage that it can also create directries, chmod files etc., so that we can do everything in one call of sftp instead of mixing scp and ssh calls.

The downside of sftp is that it can't switch to ~ resp. %userprofile% for the remote side, and we have to assume that sftp starts in the user's home dir. This is the default and works on my machines!

cdc_rsync and cdc_stream check the CDC_SFTP_COMMAND env var now and accept --sftp-command flags. If they are not set, the corresponding scp flag and env var is still used, with scp replaced by sftp. This is most likely correct as sftp and scp usually reside in the same directory and share largely identical parameters.