### PR TITLE
[cdc_rsync] Improve throughput for local copies

### DIFF
--- a/cdc_rsync/cdc_rsync_client.cc
+++ b/cdc_rsync/cdc_rsync_client.cc
@@ -623,7 +623,7 @@ absl::Status CdcRsyncClient::SendMissingFiles() {
 
   ParallelFileOpener file_opener(&files_, missing_file_indices_);
 
-  constexpr size_t kBufferSize = 16000;
+  constexpr size_t kBufferSize = 128 * 1024;
   for (uint32_t server_index = 0; server_index < missing_file_indices_.size();
        ++server_index) {
     uint32_t client_index = missing_file_indices_[server_index];

--- a/common/BUILD
+++ b/common/BUILD
@@ -142,6 +142,7 @@ cc_library(
     deps = [
         ":clock",
         ":platform",
+        ":stopwatch",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/synchronization",
     ],

--- a/common/log.cc
+++ b/common/log.cc
@@ -126,21 +126,22 @@ void ConsoleLog::WriteLogMessage(LogLevel level, const char* file, int line,
   absl::MutexLock lock(&mutex_);
 
   // Show leaner log messages in non-verbose mode.
-  bool show_file_func = GetLogLevel() <= LogLevel::kDebug;
+  bool show_time_file_func = GetLogLevel() <= LogLevel::kDebug;
   FILE* stdfile = level >= LogLevel::kError ? stderr : stdout;
 #if PLATFORM_WINDOWS
   HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
   SetConsoleTextAttribute(hConsole, GetConsoleColor(level));
-  if (show_file_func) {
-    fprintf(stdfile, "%s(%i): %s(): %s\n", file, line, func, message);
+  if (show_time_file_func) {
+    fprintf(stdfile, "%0.3f %s(%i): %s(): %s\n", stopwatch_.ElapsedSeconds(),
+            file, line, func, message);
   } else {
     fprintf(stdfile, "%s\n", message);
   }
   SetConsoleTextAttribute(hConsole, kLightGray);
 #else
-  if (show_file_func) {
-    fprintf(stdfile, "%-7s %s(%i): %s(): %s\n", GetLogLevelString(level), file,
-            line, func, message);
+  if (show_time_file_func) {
+    fprintf(stdfile, "%-7s %0.3f %s(%i): %s(): %s\n", GetLogLevelString(level),
+            stopwatch_.ElapsedSeconds(), file, line, func, message);
   } else {
     fprintf(stdfile, "%-7s %s\n", GetLogLevelString(level), message);
   }

--- a/common/log.h
+++ b/common/log.h
@@ -22,6 +22,7 @@
 #include "absl/strings/str_format.h"
 #include "absl/synchronization/mutex.h"
 #include "common/clock.h"
+#include "common/stopwatch.h"
 
 namespace cdc_ft {
 
@@ -120,6 +121,7 @@ class ConsoleLog : public Log {
       ABSL_LOCKS_EXCLUDED(mutex_);
 
  private:
+  Stopwatch stopwatch_;
   absl::Mutex mutex_;
 };
 

--- a/common/threadpool.h
+++ b/common/threadpool.h
@@ -88,8 +88,13 @@ class Threadpool {
     return outstanding_task_count_;
   }
 
-  // Block until the number of queued tasks drops below |count|.
-  void WaitForQueuedTasksAtMost(size_t count) const ABSL_LOCKS_EXCLUDED(mutex_);
+  // Block until the number of queued tasks drops below or equal to |count|, or
+  // until the timeout is exceeded, or until Shutdown() is called, whatever
+  // comes sooner. Returns true if less than or equal to |count| tasks are
+  // queued.
+  bool WaitForQueuedTasksAtMost(
+      size_t count, absl::Duration timeout = absl::InfiniteDuration()) const
+      ABSL_LOCKS_EXCLUDED(mutex_);
 
  private:
   // Background thread worker method. Picks tasks and runs them.

--- a/integration_tests/cdc_rsync/output_test.py
+++ b/integration_tests/cdc_rsync/output_test.py
@@ -115,7 +115,7 @@ class OutputTest(test_base.CdcRsyncTest):
 
     # server-side output
     self._assert_regex(
-        r'DEBUG   server_socket\.cc\([0-9]+\): Receive\(\): EOF\(\) detected',
+        r'DEBUG   \d+\.\d{3} server_socket\.cc\([0-9]+\): Receive\(\): EOF\(\) detected',
         output)
 
     # TODO: Add a check here, as currently the output is misleading
@@ -139,7 +139,7 @@ class OutputTest(test_base.CdcRsyncTest):
 
     # server-side output
     self._assert_regex(
-        r'VERBOSE message_pump\.cc\([0-9]+\): ThreadDoReceivePacket\(\): Received packet of size',
+        r'VERBOSE \d+\.\d{3} message_pump\.cc\([0-9]+\): ThreadDoReceivePacket\(\): Received packet of size',
         output)
 
   def test_quiet(self):


### PR DESCRIPTION
On Windows, fclose() seems to be very expensive for large files, where closing a 1 GB file takes up to 5 seconds. This CL calls fclose() in background threads. This tremendously improves local syncs, e.g. copying a 4.5 GB, 300 files data set takes only 7 seconds instead of 30 seconds.

Also increases the buffer size for copying from 16K to 128K (better throughput for local copies), and adds a timestamp to debug and verbose console logs (useful when comparing client and server logs).