### PR TITLE
[cdc_rsync] Enable local syncing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # CDC File Transfer
 
 Born from the ashes of Stadia, this repository contains tools for syncing and
-streaming files from Windows to Linux. They are based on Content Defined
-Chunking (CDC), in particular
+streaming files from Windows to Windows or Linux. The tools are based on Content
+Defined Chunking (CDC), in particular
 [FastCDC](https://www.usenix.org/conference/atc16/technical-sessions/presentation/xia),
 to split up files into chunks.
 
@@ -132,9 +132,9 @@ difference operation. It does not involve a per-byte hash map lookup.
 
 ## CDC Stream
 
-`cdc_stream` is a tool to stream files and directories from a Windows machine to a
-Linux device. Conceptually, it is similar to [sshfs](https://github.com/libfuse/sshfs),
-but it is optimized for read speed.
+`cdc_stream` is a tool to stream files and directories from a Windows machine to
+a Linux device. Conceptually, it is similar to
+[sshfs](https://github.com/libfuse/sshfs), but it is optimized for read speed.
 * It caches streamed data on the Linux device.
 * If a file is re-read on Linux after it changed on Windows, only the
   differences are streamed again. The rest is read from the cache.
@@ -160,6 +160,34 @@ In one case, the game is streamed via `sshfs`, in the other case we use
 <p align="center">
   <img src="docs/cdc_stream_vs_sshfs.png" alt="Comparison of cdc_stream and sshfs" width="752" />
 </p>
+
+# Supported Platforms
+
+| `cdc_rsync`                  | From                 | To                   |
+|:-----------------------------|:--------------------:|:--------------------:|
+| Windows x86_64               | &check;              | &check; <sup>1</sup> |
+| Ubuntu 22.04 x86_64          | &cross; <sup>2</sup> | &check;              |
+| Ubuntu 22.04 aarch64         | &cross;              | &cross;              |
+| macOS 13 x86_64 <sup>3</sup> | &cross;              | &cross;              |
+| macOS 13 aarch64 <sup>3</sup>| &cross;              | &cross;              |
+
+| `cdc_stream`                 | From                 | To                   |
+|:-----------------------------|:--------------------:|:--------------------:|
+| Windows x86_64               | &check;              | &cross;              |
+| Ubuntu 22.04 x86_64          | &cross;              | &check;              |
+| Ubuntu 22.04 aarch64         | &cross;              | &cross;              |
+| macOS 13 x86_64 <sup>3</sup> | &cross;              | &cross;              |
+| macOS 13 aarch64 <sup>3</sup>| &cross;              | &cross;              |
+
+<span style="font-size: 0.8rem">
+
+<sup>1</sup> Only local syncs, e.g. `cdc_rsync C:\src\* C:\dst`. Support for
+remote syncs is being added, see
+[#61](https://github.com/google/cdc-file-transfer/issues/61).  
+<sup>2</sup> See [#56](https://github.com/google/cdc-file-transfer/issues/56).  
+<sup>3</sup> See [#62](https://github.com/google/cdc-file-transfer/issues/62).
+
+</span>
 
 # Getting Started
 
@@ -190,7 +218,7 @@ To build the tools from source, the following steps have to be executed on
   git submodule update --init --recursive
   ```
 
-Finally, install an SSH client on the Windows device if not present.
+Finally, install an SSH client on the Windows machine if not present.
 The file transfer tools require `ssh.exe` and `sftp.exe`.
 
 ## Building
@@ -303,6 +331,10 @@ cdc_rsync C:\path\to\assets\* user@linux.device.com:~/assets -r
 To get per file progress, add `-v`:
 ```
 cdc_rsync C:\path\to\assets\* user@linux.device.com:~/assets -vr
+```
+The tool also supports local syncs:
+```
+cdc_rsync C:\path\to\assets\* C:\path\to\destination -vr
 ```
 
 ### CDC Stream

--- a/cdc_rsync/cdc_rsync_client.cc
+++ b/cdc_rsync/cdc_rsync_client.cc
@@ -229,10 +229,7 @@ absl::Status CdcRsyncClient::StartServer(int port, const ServerArch& arch) {
   } else {
     // Run cdc_rsync_server locally.
     std::string exe_dir;
-    absl::Status status = path::GetExeDir(&exe_dir);
-    if (!status.ok()) {
-      return WrapStatus(status, "Failed to get exe directory");
-    }
+    RETURN_IF_ERROR(path::GetExeDir(&exe_dir), "Failed to get exe directory");
 
     std::string server_path = path::Join(exe_dir, arch.CdcServerFilename());
     start_info.command =

--- a/cdc_rsync/cdc_rsync_client.h
+++ b/cdc_rsync/cdc_rsync_client.h
@@ -21,16 +21,18 @@
 #include <vector>
 
 #include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "cdc_rsync/base/message_pump.h"
 #include "cdc_rsync/client_socket.h"
 #include "cdc_rsync/progress_tracker.h"
 #include "common/path_filter.h"
-#include "common/port_manager.h"
-#include "common/remote_util.h"
+#include "common/process.h"
 
 namespace cdc_ft {
 
+class PortManager;
 class Process;
+class RemoteUtil;
 class ServerArch;
 class ZstdStream;
 
@@ -129,8 +131,8 @@ class CdcRsyncClient {
   std::vector<std::string> sources_;
   const std::string destination_;
   WinProcessFactory process_factory_;
-  RemoteUtil remote_util_;
-  PortManager port_manager_;
+  std::unique_ptr<RemoteUtil> remote_util_;
+  std::unique_ptr<PortManager> port_manager_;
   std::unique_ptr<SocketFinalizer> socket_finalizer_;
   ClientSocket socket_;
   MessagePump message_pump_{&socket_, MessagePump::PacketReceivedDelegate()};

--- a/cdc_rsync/params.cc
+++ b/cdc_rsync/params.cc
@@ -402,15 +402,13 @@ bool CheckOptionResult(OptionResult result, const std::string& name,
 // e.g. C:\foo.
 void PopUserHost(std::string* destination, std::string* user_host) {
   user_host->clear();
+
+  // Don't mistake the C part of C:\foo or \\share\C:\foo as user/host.
+  if (!path::GetDrivePrefix(*destination).empty()) return;
+
   std::vector<std::string> parts =
       absl::StrSplit(*destination, absl::MaxSplits(':', 1));
   if (parts.size() < 2) return;
-
-  // Don't mistake the C part of C:\foo as user/host.
-  if (parts[0].size() == 1 && toupper(parts[0][0]) >= 'A' &&
-      toupper(parts[0][0]) <= 'Z') {
-    return;
-  }
 
   *user_host = parts[0];
   *destination = parts[1];

--- a/cdc_rsync/params_test.cc
+++ b/cdc_rsync/params_test.cc
@@ -228,18 +228,15 @@ TEST_F(ParamsTest, ParseSucceedsWithNoSftpCommand) {
   ExpectError(NeedsValueError("sftp-command"));
 }
 
-TEST_F(ParamsTest, ParseFailsOnNoUserHost) {
+TEST_F(ParamsTest, ParseSucceedsOnNoUserHost) {
   const char* argv[] = {"cdc_rsync.exe", kSrc, kDst, NULL};
-  EXPECT_FALSE(
-      Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
-  ExpectError("No remote host specified");
+  EXPECT_TRUE(Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
 }
 
 TEST_F(ParamsTest, ParseDoesNotThinkCIsAHost) {
   const char* argv[] = {"cdc_rsync.exe", kSrc, "C:\\foo", NULL};
-  EXPECT_FALSE(
-      Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
-  ExpectError("No remote host specified");
+  EXPECT_TRUE(Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
+  EXPECT_TRUE(parameters_.user_host.empty());
 }
 
 TEST_F(ParamsTest, ParseWithoutParametersFailsOnMissingSourceAndDestination) {

--- a/cdc_rsync/params_test.cc
+++ b/cdc_rsync/params_test.cc
@@ -233,9 +233,19 @@ TEST_F(ParamsTest, ParseSucceedsOnNoUserHost) {
   EXPECT_TRUE(Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
 }
 
-TEST_F(ParamsTest, ParseDoesNotThinkCIsAHost) {
+TEST_F(ParamsTest, ParseDoesNotThinkDriveIsAHost) {
   const char* argv[] = {"cdc_rsync.exe", kSrc, "C:\\foo", NULL};
   EXPECT_TRUE(Parse(static_cast<int>(std::size(argv)) - 1, argv, &parameters_));
+  EXPECT_TRUE(parameters_.user_host.empty());
+
+  const char* argv2[] = {"cdc_rsync.exe", kSrc, "\\\\.\\C:\\foo", NULL};
+  EXPECT_TRUE(
+      Parse(static_cast<int>(std::size(argv2)) - 1, argv, &parameters_));
+  EXPECT_TRUE(parameters_.user_host.empty());
+
+  const char* argv3[] = {"cdc_rsync.exe", kSrc, "\\\\?\\C:\\foo", NULL};
+  EXPECT_TRUE(
+      Parse(static_cast<int>(std::size(argv3)) - 1, argv, &parameters_));
   EXPECT_TRUE(parameters_.user_host.empty());
 }
 

--- a/cdc_rsync/server_arch.cc
+++ b/cdc_rsync/server_arch.cc
@@ -20,6 +20,7 @@
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
 #include "common/path.h"
+#include "common/platform.h"
 #include "common/remote_util.h"
 #include "common/util.h"
 
@@ -56,6 +57,28 @@ ServerArch::Type ServerArch::Detect(const std::string& destination) {
 
   // Default to Linux.
   return Type::kLinux;
+}
+
+// static
+ServerArch::Type ServerArch::LocalType() {
+#if PLATFORM_WINDOWS
+  return ServerArch::Type::kWindows;
+#elif PLATFORM_LINUX
+  return ServerArch::Type::kLinux;
+#endif
+}
+
+// static
+std::string ServerArch::CdcRsyncFilename() {
+  switch (LocalType()) {
+    case Type::kWindows:
+      return "cdc_rsync.exe";
+    case Type::kLinux:
+      return "cdc_rsync";
+    default:
+      assert(!kErrorArchTypeUnhandled);
+      return std::string();
+  }
 }
 
 ServerArch::ServerArch(Type type) : type_(type) {}

--- a/cdc_rsync/server_arch.h
+++ b/cdc_rsync/server_arch.h
@@ -33,6 +33,12 @@ class ServerArch {
   // starting with C: indicate Windows.
   static Type Detect(const std::string& destination);
 
+  // Returns the arch type that matches the current process's type.
+  static Type LocalType();
+
+  // Returns the (local!) arch specific filename of cdc_rsync[.exe].
+  static std::string CdcRsyncFilename();
+
   ServerArch(Type type);
   ~ServerArch();
 

--- a/cdc_rsync/server_arch.h
+++ b/cdc_rsync/server_arch.h
@@ -29,7 +29,7 @@ class ServerArch {
     kWindows = 1,
   };
 
-  // Detects the architecture type based on the destination path, e.g. path
+  // Detects the arch type based on the destination path, e.g. path
   // starting with C: indicate Windows.
   static Type Detect(const std::string& destination);
 

--- a/common/path.cc
+++ b/common/path.cc
@@ -291,8 +291,8 @@ std::string GetDrivePrefix(const std::string& path) {
 
   if (path[0] != '\\') {
     size_t pos = path.find(":");
-    if (pos == std::string::npos) {
-      // E.g. "\path\to\file" or "path\to\file".
+    if (pos != 1) {
+      // E.g. "\path\to\file", "path\to\file" or "user@host:file".
       return std::string();
     }
 

--- a/common/path_test.cc
+++ b/common/path_test.cc
@@ -302,6 +302,7 @@ TEST_F(PathTest, GetDrivePrefix) {
   EXPECT_EQ(path::GetDrivePrefix("C:\\"), "C:");
   EXPECT_EQ(path::GetDrivePrefix("C:\\dir"), "C:");
   EXPECT_EQ(path::GetDrivePrefix("C:\\dir\\file"), "C:");
+  EXPECT_EQ(path::GetDrivePrefix("host:C:\\dir\\file"), "");
 }
 #endif
 

--- a/common/port_manager.h
+++ b/common/port_manager.h
@@ -40,8 +40,8 @@ class PortManager {
   // synchronize port reservation. The range of possible ports managed by this
   // instance is [|first_port|, |last_port|]. |process_factory| is a valid
   // pointer to a ProcessFactory instance to run processes locally.
-  // |remote_util| is a valid pointer to a RemoteUtil instance to run processes
-  // remotely.
+  // |remote_util| is the RemoteUtil instance to run processes remotely. If it
+  //   is nullptr, no remote ports are reserved.
   PortManager(std::string unique_name, int first_port, int last_port,
               ProcessFactory* process_factory, RemoteUtil* remote_util,
               SystemClock* system_clock = DefaultSystemClock::GetInstance(),

--- a/common/port_manager_win.cc
+++ b/common/port_manager_win.cc
@@ -131,11 +131,13 @@ absl::StatusOr<int> PortManager::ReservePort(int remote_timeout_sec) {
 
   // Find available port on remote instance.
   std::unordered_set<int> remote_ports = local_ports;
-  ASSIGN_OR_RETURN(remote_ports,
-                   FindAvailableRemotePorts(first_port_, last_port_, "0.0.0.0",
-                                            process_factory_, remote_util_,
-                                            remote_timeout_sec, steady_clock_),
-                   "Failed to find available ports on instance");
+  if (remote_util_ != nullptr) {
+    ASSIGN_OR_RETURN(remote_ports,
+                     FindAvailableRemotePorts(
+                         first_port_, last_port_, "0.0.0.0", process_factory_,
+                         remote_util_, remote_timeout_sec, steady_clock_),
+                     "Failed to find available ports on instance");
+  }
 
   // Fetch shared memory.
   void* mem;

--- a/fastcdc/fastcdc.h
+++ b/fastcdc/fastcdc.h
@@ -240,7 +240,7 @@ class ChunkerTmpl {
     }
 
     // Init hash to all 1's to avoid zero-length chunks with min_size=0.
-    uint64_t hash = (uint64_t)-1;
+    uint64_t hash = UINT64_MAX;
     // Skip the first min_size bytes, but "warm up" the rolling hash for 64
     // rounds to make sure the 64-bit hash has gathered full "content history".
     size_t i = cfg_.min_size > 64 ? cfg_.min_size - 64 : 0;


### PR DESCRIPTION
Adds support for local syncs of files and folders on the same Windows machine, e.g. cdc_rsync C:\source C:\dest. The main changes are

- Skip the check whether the port is available remotely with PortManager.
- Do not deploy cdc_rsync_server.
- Run cdc_rsync_server directly, not through an SSH tunnel.

The current implementation is not optimal as it starts cdc_rsync_server as a separate process and communicates to it via a TCP port.