### PR TITLE
Fix #76 fastcdc chunk boundary off-by-one.

### DIFF
--- a/fastcdc/fastcdc.h
+++ b/fastcdc/fastcdc.h
@@ -250,10 +250,10 @@ class ChunkerTmpl {
       uint64_t mask = stages_[stg].mask;
       size_t barrier = std::min(len, stages_[stg].barrier);
       for (/*empty*/; i < barrier; ++i) {
-        hash = (hash << 1) + gear[data[i]];
         if (!(hash & mask)) {
           return i;
         }
+        hash = (hash << 1) + gear[data[i]];
       }
     }
     return i;

--- a/fastcdc/fastcdc.h
+++ b/fastcdc/fastcdc.h
@@ -239,7 +239,8 @@ class ChunkerTmpl {
       len = cfg_.max_size;
     }
 
-    uint64_t hash = 0;
+    // Init hash to all 1's to avoid zero-length chunks with min_size=0.
+    uint64_t hash = (uint64_t)-1;
     // Skip the first min_size bytes, but "warm up" the rolling hash for 64
     // rounds to make sure the 64-bit hash has gathered full "content history".
     size_t i = cfg_.min_size > 64 ? cfg_.min_size - 64 : 0;

--- a/fastcdc/fastcdc_test.cc
+++ b/fastcdc/fastcdc_test.cc
@@ -195,7 +195,7 @@ TEST_F(ChunkerTest, MinChunkSize) {
 
 // Tests that maximum chunk size is not exceeded.
 TEST_F(ChunkerTest, MaxChunkSize) {
-  Config cfg(32, 64, 128);
+  Config cfg(0, 64, 128);
   std::vector<size_t> chunk_sizes;
   TestChunker<> chunker(cfg, [&](const uint8_t* /* data */, size_t len) {
     chunk_sizes.push_back(len);


### PR DESCRIPTION
This ensures that the last byte included in the gear-hash that identified the  chunk boundary is included in the chunk. This ensures chunks are still matched  when the byte immediately after them is changed.

It also initializes the gear hash to all 1's to avoid zero-length chunks when `min_size=0`. It changes the fastcdc `MaxChunkSize` test to use `min_size=0` to test this corner-case.