### PR TITLE
[cdc_rsync] [cdc_rsync_server] Add build ID

### DIFF
--- a/all_files.vcxitems
+++ b/all_files.vcxitems
@@ -159,6 +159,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)metrics\metrics.cc" />
     <ClInclude Include="$(MSBuildThisFileDirectory)cdc_stream\stop_service_command.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)common\ansi_filter.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)common\build_version.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)common\port_range_parser.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)fastcdc\fastcdc.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)manifest\pending_assets_queue.h" />

--- a/cdc_rsync/BUILD
+++ b/cdc_rsync/BUILD
@@ -131,6 +131,7 @@ cc_library(
     hdrs = ["params.h"],
     deps = [
         ":cdc_rsync_client",
+        "//common:build_version",
         "//common:port_range_parser",
         "@com_github_zstd//:zstd",
         "@com_google_absl//absl/status",

--- a/cdc_rsync/params.cc
+++ b/cdc_rsync/params.cc
@@ -19,6 +19,7 @@
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
+#include "common/build_version.h"
 #include "common/path.h"
 #include "common/port_range_parser.h"
 #include "common/remote_util.h"
@@ -38,8 +39,7 @@ void PrintError(const absl::FormatSpec<Args...>& format, Args... args) {
 enum class OptionResult { kConsumedKey, kConsumedKeyValue, kError };
 
 const char kHelpText[] =
-    R"(Synchronize files and directories
-
+    R"(
 Matching files are skipped based on file size and modified time. For partially
 matching files only the differences are transferred. The destination directory
 can be the same Windows machine or a remote Windows or Linux device.
@@ -323,6 +323,8 @@ OptionResult HandleParameter(const std::string& key, const char* value,
 
 bool ValidateParameters(const Parameters& params, bool help) {
   if (help) {
+    std::cout << "cdc_rsync - Synchronize files and directories. Version: "
+              << BUILD_VERSION << "\n";
     std::cout << kHelpText;
     return false;
   }

--- a/cdc_rsync_server/BUILD
+++ b/cdc_rsync_server/BUILD
@@ -100,6 +100,7 @@ cc_binary(
         "//cdc_rsync/base:cdc_interface",
         "//cdc_rsync/base:message_pump",
         "//cdc_rsync/base:server_exit_code",
+        "//common:build_version",
         "//common:clock",
         "//common:gamelet_component",
         "//common:log",

--- a/cdc_rsync_server/main.cc
+++ b/cdc_rsync_server/main.cc
@@ -14,6 +14,7 @@
 
 #include "cdc_rsync/base/server_exit_code.h"
 #include "cdc_rsync_server/cdc_rsync_server.h"
+#include "common/build_version.h"
 #include "common/gamelet_component.h"
 #include "common/log.h"
 #include "common/status.h"
@@ -60,10 +61,16 @@ ServerExitCode GetExitCode(const absl::Status& status) {
 }  // namespace cdc_ft
 
 int main(int argc, const char** argv) {
-  if (argc < 2) {
-    printf("Usage: cdc_rsync_server <port> cdc_rsync_server <size> <time> \n");
-    printf("       where <size> and <time> are the file size and modified\n");
-    printf("       timestamp (Unix epoch) of the corresponding component.\n");
+  if (argc < 5) {
+    printf("cdc_rsync_server - Remote component of cdc_rsync. Version: %s\n\n",
+           BUILD_VERSION);
+    printf(
+        "Usage: cdc_rsync_server <port> <build_version> cdc_rsync_server "
+        "<size> <time> \n");
+    printf("       where <size> is the file size, <time> is the  modified\n");
+    printf(
+        "       timestamp (Unix epoch) and <build_version> is the build "
+        "version of the server.\n");
     return cdc_ft::kServerExitCodeGenericStartup;
   }
 
@@ -82,6 +89,7 @@ int main(int argc, const char** argv) {
   cdc_ft::Log::Initialize(
       std::make_unique<cdc_ft::ConsoleLog>(cdc_ft::LogLevel::kWarning));
   cdc_ft::CdcRsyncServer server;
+
   if (!server.CheckComponents(components)) {
     return cdc_ft::kServerExitCodeOutOfDate;
   }

--- a/common/BUILD
+++ b/common/BUILD
@@ -45,6 +45,11 @@ cc_library(
 )
 
 cc_library(
+    name = "build_version",
+    hdrs = ["build_version.h"],
+)
+
+cc_library(
     name = "dir_iter",
     srcs = ["dir_iter.cc"],
     hdrs = ["dir_iter.h"],
@@ -395,6 +400,7 @@ cc_library(
         ":path",
         ":platform",
         ":status",
+        "//common:build_version",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings:str_format",
     ],

--- a/common/build_version.h
+++ b/common/build_version.h
@@ -1,0 +1,10 @@
+#ifndef BUILD_VERSION
+#define DEV_BUILD_VERSION "DEV"
+#ifdef CDC_BUILD_VERSION
+#define TO_STR(arg) #arg
+#define TO_STR_VALUE(arg) TO_STR(arg)
+#define BUILD_VERSION TO_STR_VALUE(CDC_BUILD_VERSION)
+#else
+#define BUILD_VERSION DEV_BUILD_VERSION
+#endif
+#endif

--- a/common/gamelet_component.h
+++ b/common/gamelet_component.h
@@ -28,11 +28,13 @@ namespace cdc_ft {
 // The components are considered fresh if both the timestamp and the file size
 // match.
 struct GameletComponent {
+  std::string build_version;
   std::string filename;
   uint64_t size;
   int64_t modified_time;
 
-  GameletComponent(std::string filename, uint64_t size, time_t modified_time);
+  GameletComponent(std::string build_version, std::string filename,
+                   uint64_t size, time_t modified_time);
   ~GameletComponent();
 
   bool operator==(const GameletComponent& other) const;

--- a/common/gamelet_component_test.cc
+++ b/common/gamelet_component_test.cc
@@ -15,6 +15,7 @@
 #include "common/gamelet_component.h"
 
 #include "absl/strings/str_split.h"
+#include "common/build_version.h"
 #include "common/log.h"
 #include "common/path.h"
 #include "common/status_test_macros.h"
@@ -43,14 +44,14 @@ class GameletComponentTest : public ::testing::Test {
       path::Join(base_dir_, "other", "cdc_rsync_server");
 };
 
-TEST_F(GameletComponentTest, EqualityOperators) {
+TEST_F(GameletComponentTest, EqualityOperators_DevelopmentVersion) {
   constexpr uint64_t size1 = 1001;
   constexpr uint64_t size2 = 1002;
 
   constexpr int64_t modified_time1 = 5001;
   constexpr int64_t modified_time2 = 5002;
 
-  GameletComponent a("file1", size1, modified_time1);
+  GameletComponent a(DEV_BUILD_VERSION, "file1", size1, modified_time1);
 
   GameletComponent b = a;
   EXPECT_TRUE(a == b && !(a != b));
@@ -65,6 +66,38 @@ TEST_F(GameletComponentTest, EqualityOperators) {
   b = a;
   b.modified_time = modified_time2;
   EXPECT_TRUE(!(a == b) && a != b);
+
+  b = a;
+  b.size = size2;
+  b.build_version = "Specified";
+  EXPECT_TRUE(!(a == b) && a != b);
+
+  a.build_version = "Specified";
+  EXPECT_TRUE(a == b && !(a != b));
+}
+
+TEST_F(GameletComponentTest, EqualityOperators_SpecifiedVersion) {
+  constexpr uint64_t size1 = 1001;
+  constexpr uint64_t size2 = 1002;
+
+  constexpr int64_t modified_time1 = 5001;
+  constexpr int64_t modified_time2 = 5002;
+
+  GameletComponent a("Specified", "file1", size1, modified_time1);
+
+  GameletComponent b = a;
+  EXPECT_TRUE(a == b && !(a != b));
+
+  b.filename = "file2";
+  EXPECT_TRUE(!(a == b) && a != b);
+
+  b = a;
+  b.size = size2;
+  EXPECT_TRUE(a == b && !(a != b));
+
+  b = a;
+  b.modified_time = modified_time2;
+  EXPECT_TRUE(a == b && !(a != b));
 }
 
 TEST_F(GameletComponentTest, GetValidComponents) {


### PR DESCRIPTION
Build id is an optional unique identifier specified during cdc_rsync build via CDC_BUILD_VERSION definition.
If build ids specified on both client and server components it will be used to check the version of server component instead of file size + modified time.