### PR TITLE
[cdc_rsync] Detect remote architecture

### DIFF
--- a/all_files.vcxitems
+++ b/all_files.vcxitems
@@ -41,6 +41,8 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)cdc_stream\stop_service_command.cc" />
     <ClCompile Include="$(MSBuildThisFileDirectory)common\ansi_filter.cc" />
     <ClCompile Include="$(MSBuildThisFileDirectory)common\ansi_filter_test.cc" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)common\arch_type.cc" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)common\arch_type_test.cc" />
     <ClCompile Include="$(MSBuildThisFileDirectory)common\port_range_parser.cc" />
     <ClCompile Include="$(MSBuildThisFileDirectory)common\port_range_parser_test.cc" />
     <ClCompile Include="$(MSBuildThisFileDirectory)fastcdc\fastcdc_test.cc" />
@@ -159,6 +161,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)metrics\metrics.cc" />
     <ClInclude Include="$(MSBuildThisFileDirectory)cdc_stream\stop_service_command.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)common\ansi_filter.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)common\arch_type.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)common\build_version.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)common\port_range_parser.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)fastcdc\fastcdc.h" />

--- a/cdc_rsync/BUILD
+++ b/cdc_rsync/BUILD
@@ -179,6 +179,7 @@ cc_library(
     srcs = ["server_arch.cc"],
     hdrs = ["server_arch.h"],
     deps = [
+        "//common:arch_type",
         "//common:path",
         "//common:remote_util",
         "@com_google_absl//absl/strings",

--- a/cdc_rsync/cdc_rsync_client.h
+++ b/cdc_rsync/cdc_rsync_client.h
@@ -79,7 +79,9 @@ class CdcRsyncClient {
 
  private:
   // Finds available local and remote ports for port forwarding.
-  absl::StatusOr<int> FindAvailablePort();
+  // May update |server_arch| by properly detecting the architecture and retry
+  // if the architecture was guessed, i.e. if |server_arch|->IsGuess() is true.
+  absl::StatusOr<int> FindAvailablePort(ServerArch* server_arch);
 
   // Starts the server process. If the method returns a status with tag
   // |kTagDeployServer|, Run() calls DeployServer() and tries again.

--- a/cdc_rsync/server_arch.cc
+++ b/cdc_rsync/server_arch.cc
@@ -20,60 +20,150 @@
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
 #include "common/path.h"
-#include "common/platform.h"
 #include "common/remote_util.h"
+#include "common/status_macros.h"
 #include "common/util.h"
 
 namespace cdc_ft {
+namespace {
 
-constexpr char kErrorFailedToGetKnownFolderPath[] =
-    "error_failed_to_get_known_folder_path";
 constexpr char kErrorArchTypeUnhandled[] = "arch_type_unhandled";
+constexpr char kUnsupportedArchErrorFmt[] =
+    "Unsupported remote device architecture '%s'. If you think this is a "
+    "bug, or if this combination should be supported, please file a bug at "
+    "https://github.com/google/cdc-file-transfer.";
+
+absl::StatusOr<ArchType> GetArchTypeFromUname(const std::string& uname_out) {
+  // uname_out is "KERNEL MACHINE"
+  // Possible values for KERNEL: Linux (not sure what else).
+  // Possible values for MACHINE:
+  // https://stackoverflow.com/questions/45125516/possible-values-for-uname-m
+  // Relevant for us: x86_64, aarch64.
+  if (absl::StartsWith(uname_out, "Linux ")) {
+    // Linux kernel. Check CPU type.
+    if (absl::StrContains(uname_out, "x86_64")) {
+      return ArchType::kLinux_x86_64;
+    }
+  }
+
+  if (absl::StartsWith(uname_out, "MSYS_")) {
+    // Windows machine that happens to have Cygwin/MSYS on it. Check CPU type.
+    if (absl::StrContains(uname_out, "x86_64")) {
+      return ArchType::kWindows_x86_64;
+    }
+  }
+
+  return absl::UnimplementedError(
+      absl::StrFormat(kUnsupportedArchErrorFmt, uname_out));
+}
+
+absl::StatusOr<ArchType> GetArchTypeFromWinProcArch(
+    const std::string& arch_out) {
+  // Possible values: AMD64, IA64, ARM64, x86
+  if (absl::StrContains(arch_out, "AMD64")) {
+    return ArchType::kWindows_x86_64;
+  }
+
+  return absl::UnimplementedError(
+      absl::StrFormat(kUnsupportedArchErrorFmt, arch_out));
+}
+
+}  // namespace
 
 // static
-ServerArch::Type ServerArch::Detect(const std::string& destination) {
+ServerArch ServerArch::GuessFromDestination(const std::string& destination) {
   // Path starting with ~ or / -> Linux.
   if (absl::StartsWith(destination, "~") ||
       absl::StartsWith(destination, "/")) {
-    return Type::kLinux;
+    LOG_DEBUG("Guessed server arch type Linux based on ~ or /");
+    return ServerArch(ArchType::kLinux_x86_64, /*is_guess=*/true);
   }
 
   // Path starting with C: etc. -> Windows.
   if (!path::GetDrivePrefix(destination).empty()) {
-    return Type::kWindows;
+    LOG_DEBUG("Guessed server arch type Windows based on drive prefix");
+    return ServerArch(ArchType::kWindows_x86_64, /*is_guess=*/true);
   }
 
   // Path with only / -> Linux.
   if (absl::StrContains(destination, "/") &&
       !absl::StrContains(destination, "\\")) {
-    return Type::kLinux;
+    LOG_DEBUG("Guessed server arch type Linux based on forward slashes");
+    return ServerArch(ArchType::kLinux_x86_64, /*is_guess=*/true);
   }
 
   // Path with only \\ -> Windows.
   if (absl::StrContains(destination, "\\") &&
       !absl::StrContains(destination, "/")) {
-    return Type::kWindows;
+    LOG_DEBUG("Guessed server arch type Windows based on backslashes");
+    return ServerArch(ArchType::kWindows_x86_64, /*is_guess=*/true);
   }
 
   // Default to Linux.
-  return Type::kLinux;
+  LOG_DEBUG("Guessed server arch type Linux as default");
+  return ServerArch(ArchType::kLinux_x86_64, /*is_guess=*/true);
 }
 
 // static
-ServerArch::Type ServerArch::LocalType() {
-#if PLATFORM_WINDOWS
-  return ServerArch::Type::kWindows;
-#elif PLATFORM_LINUX
-  return ServerArch::Type::kLinux;
-#endif
+ServerArch ServerArch::DetectFromLocalDevice() {
+  LOG_DEBUG("Detected local device type %s",
+            GetArchTypeStr(GetLocalArchType()));
+  return ServerArch(GetLocalArchType(), /*is_guess=*/false);
+}
+
+// static
+absl::StatusOr<ServerArch> ServerArch::DetectFromRemoteDevice(
+    RemoteUtil* remote_util) {
+  assert(remote_util);
+
+  // Run uname, assuming it's a Linux machine.
+  std::string uname_out;
+  std::string linux_cmd = "uname -sm";
+  absl::Status status =
+      remote_util->RunWithCapture(linux_cmd, "uname", &uname_out, nullptr);
+  if (status.ok()) {
+    LOG_DEBUG("Uname returned '%s'", uname_out);
+    absl::StatusOr<ArchType> type = GetArchTypeFromUname(uname_out);
+    if (type.ok()) {
+      LOG_DEBUG("Detected server arch type %s from uname",
+                GetArchTypeStr(*type));
+      return ServerArch(*type, /*is_guess=*/false);
+    }
+    status = type.status();
+  }
+  LOG_DEBUG("Failed to detect arch type from uname: %s", status.ToString());
+
+  // Run echo %PROCESSOR_ARCHITECTURE%, assuming it's a Windows machine.
+  // Note: That space after PROCESSOR_ARCHITECTURE is important or else Windows
+  //       command magic interprets quotes as part of the string.
+  std::string arch_out;
+  std::string windows_cmd =
+      RemoteUtil::QuoteForSsh("cmd /C set PROCESSOR_ARCHITECTURE ");
+  status = remote_util->RunWithCapture(windows_cmd,
+                                       "set PROCESSOR_ARCHITECTURE", &arch_out,
+                                       nullptr, ArchType::kWindows_x86_64);
+  if (status.ok()) {
+    LOG_DEBUG("%PROCESSOR_ARCHITECTURE% is '%s'", arch_out);
+    absl::StatusOr<ArchType> type = GetArchTypeFromWinProcArch(arch_out);
+    if (type.ok()) {
+      LOG_DEBUG("Detected server arch type %s from %%PROCESSOR_ARCHITECTURE%%",
+                GetArchTypeStr(*type));
+      return ServerArch(*type, /*is_guess=*/false);
+    }
+    status = type.status();
+  }
+  LOG_DEBUG("Failed to detect arch type from %%PROCESSOR_ARCHITECTURE%%: %s",
+            status.ToString());
+
+  return absl::InternalError("Failed to detect remote architecture");
 }
 
 // static
 std::string ServerArch::CdcRsyncFilename() {
-  switch (LocalType()) {
-    case Type::kWindows:
+  switch (GetLocalArchType()) {
+    case ArchType::kWindows_x86_64:
       return "cdc_rsync.exe";
-    case Type::kLinux:
+    case ArchType::kLinux_x86_64:
       return "cdc_rsync";
     default:
       assert(!kErrorArchTypeUnhandled);
@@ -81,15 +171,18 @@ std::string ServerArch::CdcRsyncFilename() {
   }
 }
 
-ServerArch::ServerArch(Type type) : type_(type) {}
+ServerArch::ServerArch(ArchType type, bool is_guess)
+    : type_(type), is_guess_(is_guess) {}
 
 ServerArch::~ServerArch() {}
 
+const char* ServerArch::GetTypeStr() const { return GetArchTypeStr(type_); }
+
 std::string ServerArch::CdcServerFilename() const {
   switch (type_) {
-    case Type::kWindows:
+    case ArchType::kWindows_x86_64:
       return "cdc_rsync_server.exe";
-    case Type::kLinux:
+    case ArchType::kLinux_x86_64:
       return "cdc_rsync_server";
     default:
       assert(!kErrorArchTypeUnhandled);
@@ -98,46 +191,46 @@ std::string ServerArch::CdcServerFilename() const {
 }
 
 std::string ServerArch::RemoteToolsBinDir() const {
-  switch (type_) {
-    case Type::kWindows: {
-      return "AppData\\Roaming\\cdc-file-transfer\\bin\\";
-    }
-    case Type::kLinux:
-      return ".cache/cdc-file-transfer/bin/";
-    default:
-      assert(!kErrorArchTypeUnhandled);
-      return std::string();
+  if (IsWindowsArchType(type_)) {
+    return "AppData\\Roaming\\cdc-file-transfer\\bin\\";
   }
+
+  if (IsLinuxArchType(type_)) {
+    return ".cache/cdc-file-transfer/bin/";
+  }
+
+  assert(!kErrorArchTypeUnhandled);
+  return std::string();
 }
 
 std::string ServerArch::GetStartServerCommand(int exit_code_not_found,
                                               const std::string& args) const {
   std::string server_path = RemoteToolsBinDir() + CdcServerFilename();
 
-  switch (type_) {
-    case Type::kWindows:
-      // TODO(ljusten): On Windows, ssh does not seem to forward the Powershell
-      // exit code (exit_code_not_found) to the process. However, that's really
-      // a minor issue and means we display "Deploying server..." instead of
-      // "Server not deployed. Deploying...";
-      return RemoteUtil::QuoteForWindows(
-          absl::StrFormat("powershell -Command \" "
-                          "Set-StrictMode -Version 2; "
-                          "$ErrorActionPreference = 'Stop'; "
-                          "if (-not (Test-Path -Path '%s')) { "
-                          "  exit %i; "
-                          "} "
-                          "%s %s "
-                          "\"",
-                          server_path, exit_code_not_found, server_path, args));
-    case Type::kLinux:
-      return absl::StrFormat("if [ ! -f %s ]; then exit %i; fi; %s %s",
-                             server_path, exit_code_not_found, server_path,
-                             args);
-    default:
-      assert(!kErrorArchTypeUnhandled);
-      return std::string();
+  if (IsWindowsArchType(type_)) {
+    // TODO(ljusten): On Windows, ssh does not seem to forward the Powershell
+    // exit code (exit_code_not_found) to the process. However, that's really
+    // a minor issue and means we display "Deploying server..." instead of
+    // "Server not deployed. Deploying...";
+    return RemoteUtil::QuoteForWindows(
+        absl::StrFormat("powershell -Command \" "
+                        "Set-StrictMode -Version 2; "
+                        "$ErrorActionPreference = 'Stop'; "
+                        "if (-not (Test-Path -Path '%s')) { "
+                        "  exit %i; "
+                        "} "
+                        "%s %s "
+                        "\"",
+                        server_path, exit_code_not_found, server_path, args));
   }
+
+  if (IsLinuxArchType(type_)) {
+    return absl::StrFormat("if [ ! -f %s ]; then exit %i; fi; %s %s",
+                           server_path, exit_code_not_found, server_path, args);
+  }
+
+  assert(!kErrorArchTypeUnhandled);
+  return std::string();
 }
 
 std::string ServerArch::GetDeploySftpCommands() const {

--- a/cdc_stream/multi_session.cc
+++ b/cdc_stream/multi_session.cc
@@ -441,9 +441,9 @@ absl::Status MultiSession::Initialize() {
     std::unordered_set<int> ports;
     ASSIGN_OR_RETURN(
         ports,
-        PortManager::FindAvailableLocalPorts(cfg_.forward_port_first,
-                                             cfg_.forward_port_last,
-                                             "127.0.0.1", process_factory_),
+        PortManager::FindAvailableLocalPorts(
+            cfg_.forward_port_first, cfg_.forward_port_last,
+            ArchType::kWindows_x86_64, process_factory_),
         "Failed to find an available local port in the range [%d, %d]",
         cfg_.forward_port_first, cfg_.forward_port_last);
     assert(!ports.empty());

--- a/cdc_stream/session.cc
+++ b/cdc_stream/session.cc
@@ -77,8 +77,8 @@ absl::Status Session::Start(int local_port, int first_remote_port,
     ASSIGN_OR_RETURN(
         ports,
         PortManager::FindAvailableRemotePorts(
-            first_remote_port, last_remote_port, "127.0.0.1", process_factory_,
-            &remote_util_, kInstanceConnectionTimeoutSec),
+            first_remote_port, last_remote_port, ArchType::kLinux_x86_64,
+            process_factory_, &remote_util_, kInstanceConnectionTimeoutSec),
         "Failed to find an available remote port in the range [%d, %d]",
         first_remote_port, last_remote_port);
     assert(!ports.empty());

--- a/common/BUILD
+++ b/common/BUILD
@@ -19,6 +19,24 @@ cc_test(
 )
 
 cc_library(
+    name = "arch_type",
+    srcs = ["arch_type.cc"],
+    hdrs = ["arch_type.h"],
+    deps = [":platform"],
+)
+
+cc_test(
+    name = "arch_type_test",
+    srcs = ["arch_type_test.cc"],
+    deps = [
+        ":arch_type",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "buffer",
     srcs = ["buffer.cc"],
     hdrs = ["buffer.h"],
@@ -254,6 +272,7 @@ cc_library(
     hdrs = ["port_manager.h"],
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
+        ":arch_type",
         ":remote_util",
         ":status",
         ":stopwatch",
@@ -360,6 +379,7 @@ cc_library(
     srcs = ["remote_util.cc"],
     hdrs = ["remote_util.h"],
     deps = [
+        ":arch_type",
         ":platform",
         ":process",
         ":sdk_util",

--- a/common/arch_type.cc
+++ b/common/arch_type.cc
@@ -1,0 +1,70 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/arch_type.h"
+
+#include <cassert>
+
+#include "common/platform.h"
+
+namespace cdc_ft {
+
+static constexpr char kUnhandledArchType[] = "Unhandled arch type";
+
+ArchType GetLocalArchType() {
+  // TODO(ljusten): Take CPU architecture into account.
+#if PLATFORM_WINDOWS
+  return ArchType::kWindows_x86_64;
+#elif PLATFORM_LINUX
+  return ArchType::kLinux_x86_64;
+#endif
+}
+
+bool IsWindowsArchType(ArchType arch_type) {
+  switch (arch_type) {
+    case ArchType::kWindows_x86_64:
+      return true;
+    case ArchType::kLinux_x86_64:
+      return false;
+    default:
+      assert(!kUnhandledArchType);
+      return false;
+  }
+}
+
+bool IsLinuxArchType(ArchType arch_type) {
+  switch (arch_type) {
+    case ArchType::kWindows_x86_64:
+      return false;
+    case ArchType::kLinux_x86_64:
+      return true;
+    default:
+      assert(!kUnhandledArchType);
+      return false;
+  }
+}
+
+const char* GetArchTypeStr(ArchType arch_type) {
+  switch (arch_type) {
+    case ArchType::kWindows_x86_64:
+      return "Windows x86_64";
+    case ArchType::kLinux_x86_64:
+      return "Linux x86_64";
+    default:
+      assert(!kUnhandledArchType);
+      return "Unknown";
+  }
+}
+
+}  // namespace cdc_ft

--- a/common/arch_type.cc
+++ b/common/arch_type.cc
@@ -58,9 +58,9 @@ bool IsLinuxArchType(ArchType arch_type) {
 const char* GetArchTypeStr(ArchType arch_type) {
   switch (arch_type) {
     case ArchType::kWindows_x86_64:
-      return "Windows x86_64";
+      return "Windows_x86_64";
     case ArchType::kLinux_x86_64:
-      return "Linux x86_64";
+      return "Linux_x86_64";
     default:
       assert(!kUnhandledArchType);
       return "Unknown";

--- a/common/arch_type.h
+++ b/common/arch_type.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef COMMON_ARCH_TYPE_H_
+#define COMMON_ARCH_TYPE_H_
+
+namespace cdc_ft {
+
+enum class ArchType {
+  kWindows_x86_64 = 0,
+  kLinux_x86_64 = 1,
+};
+
+// Returns the arch type of the current process.
+ArchType GetLocalArchType();
+
+// Returns true if |arch_type| is a Windows operating system.
+bool IsWindowsArchType(ArchType arch_type);
+
+// Returns true if |arch_type| is a Linux operating system.
+bool IsLinuxArchType(ArchType arch_type);
+
+// Returns a human readable string for |arch_type|.
+const char* GetArchTypeStr(ArchType arch_type);
+
+}  // namespace cdc_ft
+
+#endif  // COMMON_ARCH_TYPE_H_

--- a/common/arch_type_test.cc
+++ b/common/arch_type_test.cc
@@ -1,0 +1,49 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/arch_type.h"
+
+#include "absl/strings/match.h"
+#include "gtest/gtest.h"
+
+namespace cdc_ft {
+namespace {
+
+TEST(ArchTypeTest, GetLocalArchType) {
+#if PLATFORM_WINDOWS
+  EXPECT_TRUE(IsPlatformWindows(GetLocalArchType()));
+#elif PLATFORM_LINUX
+  EXPECT_TRUE(IsPlatformLinux(GetLocalArchType()));
+#endif
+}
+
+TEST(ArchTypeTest, IsWindowsArchType) {
+  EXPECT_TRUE(IsWindowsArchType(ArchType::kWindows_x86_64));
+  EXPECT_FALSE(IsWindowsArchType(ArchType::kLinux_x86_64));
+}
+
+TEST(ArchTypeTest, IsLinuxArchType) {
+  EXPECT_FALSE(IsLinuxArchType(ArchType::kWindows_x86_64));
+  EXPECT_TRUE(IsLinuxArchType(ArchType::kLinux_x86_64));
+}
+
+TEST(ArchTypeTest, GetArchTypeStr) {
+  EXPECT_TRUE(
+      absl::StrContains(GetArchTypeStr(ArchType::kWindows_x86_64), "Windows"));
+  EXPECT_TRUE(
+      absl::StrContains(GetArchTypeStr(ArchType::kLinux_x86_64), "Linux"));
+}
+
+}  // namespace
+}  // namespace cdc_ft

--- a/common/remote_util.h
+++ b/common/remote_util.h
@@ -25,7 +25,7 @@
 
 namespace cdc_ft {
 
-// Utilities for executing remote commands on a gamelet through SSH.
+// Utilities for executing remote commands on a remote device through SSH.
 // Windows-only.
 class RemoteUtil {
  public:
@@ -63,8 +63,8 @@ class RemoteUtil {
   // Returns bad results for tricky strings like "C:\scp.path\scp.exe".
   static std::string ScpToSftpCommand(std::string scp_command);
 
-  // Copies |source_filepaths| to the remote folder |dest| on the gamelet using
-  // scp. If |compress| is true, compressed upload is used.
+  // Copies |source_filepaths| to the remote folder |dest| on the remove device
+  // using scp. If |compress| is true, compressed upload is used.
   absl::Status Scp(std::vector<std::string> source_filepaths,
                    const std::string& dest, bool compress);
 
@@ -86,27 +86,32 @@ class RemoteUtil {
   absl::Status Sftp(const std::string& commands,
                     const std::string& initial_local_dir, bool compress);
 
-  // Calls 'chmod |mode| |remote_path|' on the gamelet.
+  // Calls 'chmod |mode| |remote_path|' on the remote device.
   absl::Status Chmod(const std::string& mode, const std::string& remote_path,
                      bool quiet = false);
 
-  // Runs |remote_command| on the gamelet. The command must be properly escaped.
-  // |name| is the name of the command displayed in the logs.
+  // Runs |remote_command| on the remote device. The command must be properly
+  // escaped. |name| is the name of the command displayed in the logs.
   absl::Status Run(std::string remote_command, std::string name);
 
-  // Builds an SSH command that executes |remote_command| on the gamelet.
+  // Same as Run(), but captures both stdout and stderr.
+  // If |std_out| or |std_err| are nullptr, the output is not captured.
+  absl::Status RunWithCapture(std::string remote_command, std::string name,
+                              std::string* std_out, std::string* std_err);
+
+  // Builds an SSH command that executes |remote_command| on the remote device.
   ProcessStartInfo BuildProcessStartInfoForSsh(std::string remote_command);
 
-  // Builds an SSH command that runs SSH port forwarding to the gamelet, using
-  // the given |local_port| and |remote_port|.
-  // If |reverse| is true, sets up reverse port forwarding.
+  // Builds an SSH command that runs SSH port forwarding to the remote device,
+  // using the given |local_port| and |remote_port|. If |reverse| is true, sets
+  // up reverse port forwarding.
   ProcessStartInfo BuildProcessStartInfoForSshPortForward(int local_port,
                                                           int remote_port,
                                                           bool reverse);
 
-  // Builds an SSH command that executes |remote_command| on the gamelet, using
-  // port forwarding with given |local_port| and |remote_port|.
-  // If |reverse| is true, sets up reverse port forwarding.
+  // Builds an SSH command that executes |remote_command| on the remote device,
+  // using port forwarding with given |local_port| and |remote_port|. If
+  // |reverse| is true, sets up reverse port forwarding.
   ProcessStartInfo BuildProcessStartInfoForSshPortForwardAndCommand(
       int local_port, int remote_port, bool reverse,
       std::string remote_command);

--- a/tests_common/BUILD
+++ b/tests_common/BUILD
@@ -22,6 +22,7 @@ cc_binary(
     ],
     deps = [
         "//common:ansi_filter",
+        "//common:arch_type",
         "//common:buffer",
         "//common:dir_iter",
         "//common:file_watcher",


### PR DESCRIPTION
Improves ServerArch so that it can detect the remote architecture by running uname and checking %PROCESSOR_ARCHITECTURE%. So far, only x64 Linux and x64 Windows are supported, but in the future it is easy to add support for others, e.g. aarch64, as well.

Before the detection is run, the remote architecture is guessed first based on the destination. For instance, if the destination directory starts with "C:\", it pretty much means Windows. If cdc_rsync_server exists and runs fine, there's no need for detection.

Since also PortManager depends on the remote architecture, it has to be adjusted as well. So far, PortManager assumeed that "local" means Windows and "remote" means Linux. This is no longer the case for syncing to Windows devices, so this CL adds the necessary abstractions to PortManager.