### PR TITLE
[PortManager] Prefer ss over netstat on Linux

### DIFF
--- a/cdc_rsync/cdc_rsync_client.cc
+++ b/cdc_rsync/cdc_rsync_client.cc
@@ -146,6 +146,9 @@ absl::Status CdcRsyncClient::Run() {
     // Check whether we guessed the arch type wrong and try again.
     // Note that in case of a local sync, or if the server actively reported
     // that it's out-dated, there's no need to detect the arch.
+    LOG_DEBUG(
+        "Failed to start server, retrying after detecting remote arch: %s",
+        status.ToString());
     const ArchType old_type = server_arch.GetType();
     ASSIGN_OR_RETURN(server_arch,
                      ServerArch::DetectFromRemoteDevice(remote_util_.get()));
@@ -219,6 +222,9 @@ absl::StatusOr<int> CdcRsyncClient::FindAvailablePort(ServerArch* server_arch) {
   // the arch was wrong. Properly detect it and try again if it changed.
   if (!port.ok() && server_arch->IsGuess()) {
     const ArchType old_type = server_arch->GetType();
+    LOG_DEBUG(
+        "Failed to reserve port, retrying after detecting remote arch: %s",
+        port.status().ToString());
     ASSIGN_OR_RETURN(*server_arch,
                      ServerArch::DetectFromRemoteDevice(remote_util_.get()));
     assert(!server_arch->IsGuess());

--- a/cdc_rsync/main.cc
+++ b/cdc_rsync/main.cc
@@ -68,8 +68,8 @@ ReturnCode TagToMessage(cdc_ft::Tag tag,
 
     case cdc_ft::Tag::kDeployServer:
       *msg =
-          "Failed to deploy the instance components for unknown reasons. "
-          "Please report this issue.";
+          "Failed to deploy or run the instance components for unknown "
+          "reasons. Please report this issue.";
       return ReturnCode::kDeployFailed;
 
     case cdc_ft::Tag::kConnectionTimeout:

--- a/cdc_rsync/zstd_stream.cc
+++ b/cdc_rsync/zstd_stream.cc
@@ -146,10 +146,10 @@ void ZstdStream::ThreadCompressorMain() {
     const ZSTD_EndDirective mode = last_chunk_ ? ZSTD_e_end
                                    : flush     ? ZSTD_e_flush
                                                : ZSTD_e_continue;
-    LOG_DEBUG("Compressing %u bytes (mode=%s)", in_buffer_.size(),
-              mode == ZSTD_e_end     ? "end"
-              : mode == ZSTD_e_flush ? "flush"
-                                     : "continue");
+    LOG_VERBOSE("Compressing %u bytes (mode=%s)", in_buffer_.size(),
+                mode == ZSTD_e_end     ? "end"
+                : mode == ZSTD_e_flush ? "flush"
+                                       : "continue");
     ZSTD_inBuffer input = {in_buffer_.data(), in_buffer_.size(), 0};
     bool finished = false;
     do {

--- a/common/port_manager_win.cc
+++ b/common/port_manager_win.cc
@@ -43,10 +43,12 @@ const char* GetNetstatCommand(ArchType arch_type) {
   }
 
   if (IsLinuxArchType(arch_type)) {
+    // Prefer ss over netstat. The flags out output are compatible.
     // --numeric to get numerical addresses.
     // --listening to get only listening sockets.
     // --tcp to get only TCP connections.
-    return "netstat --numeric --listening --tcp";
+    return "which ss2 && ss --numeric --listening --tcp || netstat "
+           "--numeric --listening --tcp";
   }
 
   assert(!kErrorArchTypeUnhandled);


### PR DESCRIPTION
ss is a modern alternative to netstat. The flags we use and the way we parse the output are compatible with netstat. Since netstat is no longer installed on some Linux distributions, prefer ss, but fall back to netstat if "which ss" fails.

Also tweaks some logging.