### PR TITLE
[cdc_rsync] Fix issue with IPV6 localhosts

### DIFF
--- a/cdc_rsync_server/BUILD
+++ b/cdc_rsync_server/BUILD
@@ -140,6 +140,7 @@ cc_library(
         "//common:status",
         "//common:util",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
     ],
 )
 

--- a/cdc_rsync_server/cdc_rsync_server.cc
+++ b/cdc_rsync_server/cdc_rsync_server.cc
@@ -24,6 +24,7 @@
 #include "common/log.h"
 #include "common/path.h"
 #include "common/status.h"
+#include "common/status_macros.h"
 #include "common/stopwatch.h"
 #include "common/threadpool.h"
 #include "common/util.h"
@@ -295,10 +296,11 @@ absl::Status CdcRsyncServer::Run(int port) {
   socket_finalizer_ = std::make_unique<SocketFinalizer>();
 
   socket_ = std::make_unique<ServerSocket>();
-  status = socket_->StartListening(port);
-  if (!status.ok()) {
-    return WrapStatus(status, "Failed to start listening on port %i", port);
-  }
+  int new_port;
+  ASSIGN_OR_RETURN(new_port, socket_->StartListening(port),
+                   "Failed to start listening on port %i", port);
+  assert(port != 0);
+  assert(port == new_port);
   LOG_INFO("cdc_rsync_server listening on port %i", port);
 
   // This is the marker for the client, so it knows it can connect.

--- a/cdc_rsync_server/server_socket.h
+++ b/cdc_rsync_server/server_socket.h
@@ -18,7 +18,10 @@
 #define CDC_RSYNC_SERVER_SERVER_SOCKET_H_
 
 #include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "cdc_rsync/base/socket.h"
+
+struct addrinfo;
 
 namespace cdc_ft {
 
@@ -28,7 +31,9 @@ class ServerSocket : public Socket {
   ~ServerSocket();
 
   // Starts listening for connections on |port|.
-  absl::Status StartListening(int port);
+  // Passing 0 as port will bind to any available port.
+  // Returns the port that was bound to.
+  absl::StatusOr<int> StartListening(int port);
 
   // Stops listening for connections. No-op if already stopped/never started.
   void StopListening();
@@ -50,6 +55,11 @@ class ServerSocket : public Socket {
                        size_t* bytes_received) override;
 
  private:
+  // Called by StartListening() for a specific IPV4 or IPV6 |addr_info|.
+  // Passing 0 as port will bind to any available port.
+  // Returns the port that was bound to.
+  absl::StatusOr<int> StartListeningInternal(int port, addrinfo* addr);
+
   std::unique_ptr<struct ServerSocketInfo> socket_info_;
 };
 


### PR DESCRIPTION
Fixes an issue with port forwarding when localhost on the remote system maps to the IPV6 localhost. In that case the server would time out on accept() since it creates an IPV4 socket, so the connection is never established.

Also allows passing in port 0, so that it will auto-detect an available port. This will be used in a future CL to remove the necessity of running netstat/ss.