### PR TITLE
[cdc_rsync] Use any available server port

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -63,7 +63,6 @@ jobs:
                      --test_output=errors --local_test_jobs=1  \
                      -- //... -//third_party/... -//cdc_rsync_server:file_finder_test
 
-      # The artifact collector doesn't like the fact that bazel-bin is a symlink.
       - name: Copy artifacts
         run: |
           mkdir artifacts
@@ -152,7 +151,6 @@ jobs:
             //manifest/... `
             //metrics/...
 
-      # The artifact collector doesn't like the fact that bazel-bin is a symlink.
       - name: Copy artifacts
         run: |
           mkdir artifacts

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/cdc_rsync/client_socket.cc
+++ b/cdc_rsync/client_socket.cc
@@ -68,11 +68,10 @@ absl::Status ClientSocket::Connect(int port) {
   int count = 0;
   for (addrinfo* curr = addr_infos; curr; curr = curr->ai_next, count++) {
     socket_info_->socket =
-        socket(addr_infos->ai_family, addr_infos->ai_socktype,
-               addr_infos->ai_protocol);
+        socket(curr->ai_family, curr->ai_socktype, curr->ai_protocol);
     if (socket_info_->socket == INVALID_SOCKET) {
       LOG_DEBUG("socket() failed for addr_info %i: %s", count,
-                Util::GetWin32Error(WSAGetLastError()).c_str());
+                Util::GetWin32Error(WSAGetLastError()));
       continue;
     }
 
@@ -80,7 +79,8 @@ absl::Status ClientSocket::Connect(int port) {
     result = connect(socket_info_->socket, curr->ai_addr,
                      static_cast<int>(curr->ai_addrlen));
     if (result == SOCKET_ERROR) {
-      LOG_DEBUG("connect() failed for addr_info %i: %i", count, result);
+      LOG_DEBUG("connect() failed for addr_info %i: %s", count,
+                Util::GetWin32Error(WSAGetLastError()));
       closesocket(socket_info_->socket);
       socket_info_->socket = INVALID_SOCKET;
       continue;

--- a/cdc_rsync_server/cdc_rsync_server.h
+++ b/cdc_rsync_server/cdc_rsync_server.h
@@ -43,9 +43,10 @@ class CdcRsyncServer {
   // up-to-date by checking their sizes and timestamps.
   bool CheckComponents(const std::vector<GameletComponent>& components);
 
-  // Listens to |port|, accepts a connection from the client and runs the rsync
-  // procedure.
-  absl::Status Run(int port);
+  // Listens to any available port, accepts a connection from the client and
+  // runs the rsync procedure. Prints "Port <n>: Server is listening" to stdout,
+  // so the client can retrieve the selected port.
+  absl::Status Run();
 
   // Returns the verbosity sent from the client. 0 by default.
   int GetVerbosity() const { return verbosity_; }

--- a/cdc_rsync_server/main.cc
+++ b/cdc_rsync_server/main.cc
@@ -62,29 +62,22 @@ ServerExitCode GetExitCode(const absl::Status& status) {
 
 int main(int argc, const char** argv) {
   if (argc < 5) {
-    printf("cdc_rsync_server - Remote component of cdc_rsync. Version: %s\n\n",
-           BUILD_VERSION);
-    printf(
-        "Usage: cdc_rsync_server <port> <build_version> cdc_rsync_server "
-        "<size> <time> \n");
-    printf("       where <size> is the file size, <time> is the  modified\n");
-    printf(
-        "       timestamp (Unix epoch) and <build_version> is the build "
-        "version of the server.\n");
-    return cdc_ft::kServerExitCodeGenericStartup;
-  }
+    printf(R"("cdc_rsync_server - Remote component of cdc_rsync. Version: %s
 
-  int port = atoi(argv[1]);
-  if (port == 0) {
-    SendErrorMessage(absl::StrFormat("Invalid port '%s'", argv[1]).c_str());
+Usage: cdc_rsync_server <build_version> cdc_rsync_server <size> <modified_time>
+       <build_version>            build version embedded in the component
+       <size>                     file size of the component
+       <modified_time>            timestamp (Unix epoch) of the component)",
+           BUILD_VERSION);
+
     return cdc_ft::kServerExitCodeGenericStartup;
   }
 
   // The rest is expected to be sets of gamelet component info consisting of
-  // (filename, filesize, modified_time). This is used check whether the
+  // (version, filename, size, modified_time). This is used check whether the
   // components are up-to-date.
   std::vector<cdc_ft::GameletComponent> components =
-      cdc_ft::GameletComponent::FromCommandLineArgs(argc - 2, argv + 2);
+      cdc_ft::GameletComponent::FromCommandLineArgs(argc - 1, argv + 1);
 
   cdc_ft::Log::Initialize(
       std::make_unique<cdc_ft::ConsoleLog>(cdc_ft::LogLevel::kWarning));
@@ -94,7 +87,7 @@ int main(int argc, const char** argv) {
     return cdc_ft::kServerExitCodeOutOfDate;
   }
 
-  absl::Status status = server.Run(port);
+  absl::Status status = server.Run();
   if (status.ok()) {
     return 0;
   }

--- a/common/port_manager_test.cc
+++ b/common/port_manager_test.cc
@@ -118,9 +118,8 @@ TEST_F(PortManagerTest, ReservePortLocalNetstatFails) {
   absl::StatusOr<int> port =
       port_manager_.ReservePort(kTimeoutSec, ArchType::kLinux_x86_64);
   EXPECT_NOT_OK(port);
-  EXPECT_TRUE(
-      absl::StrContains(port.status().message(),
-                        "Failed to find available ports on workstation"));
+  EXPECT_TRUE(absl::StrContains(port.status().message(),
+                                "Failed to find available local ports"));
 }
 
 TEST_F(PortManagerTest, ReservePortRemoteNetstatFails) {
@@ -131,7 +130,7 @@ TEST_F(PortManagerTest, ReservePortRemoteNetstatFails) {
       port_manager_.ReservePort(kTimeoutSec, ArchType::kLinux_x86_64);
   EXPECT_NOT_OK(port);
   EXPECT_TRUE(absl::StrContains(port.status().message(),
-                                "Failed to find available ports on instance"));
+                                "Failed to find available remote ports"));
 }
 
 TEST_F(PortManagerTest, ReservePortRemoteNetstatTimesOut) {


### PR DESCRIPTION
Instead of calling netstat on the remote device to detect available ports, simply call bind with port 0 to bind to any available port. Since the port is not yet known when cdc_rsync_server.exe is called, port forwarding needs to be started AFTER the server reports its port.